### PR TITLE
Sub-lenders

### DIFF
--- a/app/controllers/data_corrections_controller.rb
+++ b/app/controllers/data_corrections_controller.rb
@@ -29,6 +29,7 @@ class DataCorrectionsController < ApplicationController
     if @presenter.save
       redirect_to loan_url(@loan)
     else
+      @loan.reload
       render :new
     end
   end

--- a/app/controllers/data_corrections_controller.rb
+++ b/app/controllers/data_corrections_controller.rb
@@ -7,6 +7,7 @@ class DataCorrectionsController < ApplicationController
     'lender_reference' => LenderReferenceDataCorrection,
     'postcode' => PostcodeDataCorrection,
     'sortcode' => SortcodeDataCorrection,
+    'sub_lender' => SubLenderDataCorrection,
     'trading_date' => TradingDateDataCorrection,
     'trading_name' => TradingNameDataCorrection,
   }

--- a/app/controllers/sub_lenders_controller.rb
+++ b/app/controllers/sub_lenders_controller.rb
@@ -1,9 +1,27 @@
 class SubLendersController < ApplicationController
+  include AuditableController
 
   before_filter :load_lender
 
   def index
     @sub_lenders = @lender.sub_lenders
+  end
+
+  def new
+    @sub_lender = @lender.sub_lenders.new
+  end
+
+  def create
+    @sub_lender = @lender.sub_lenders.new
+    @sub_lender.attributes = params[:sub_lender]
+
+    save = -> { @sub_lender.save }
+
+    if audit(AdminAudit::SubLenderCreated, @sub_lender, &save)
+      redirect_to lender_sub_lenders_url(@lender)
+    else
+      render :new
+    end
   end
 
   private

--- a/app/controllers/sub_lenders_controller.rb
+++ b/app/controllers/sub_lenders_controller.rb
@@ -24,6 +24,23 @@ class SubLendersController < ApplicationController
     end
   end
 
+  def edit
+    @sub_lender = @lender.sub_lenders.find(params[:id])
+  end
+
+  def update
+    @sub_lender = @lender.sub_lenders.find(params[:id])
+    @sub_lender.attributes = params[:sub_lender].slice(:name)
+
+    save = -> { @sub_lender.save }
+
+    if audit(AdminAudit::SubLenderEdited, @sub_lender, &save)
+      redirect_to lender_sub_lenders_url(@lender)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def load_lender

--- a/app/controllers/sub_lenders_controller.rb
+++ b/app/controllers/sub_lenders_controller.rb
@@ -1,6 +1,11 @@
 class SubLendersController < ApplicationController
   include AuditableController
 
+  before_filter :verify_create_permission, only: [:new, :create]
+  before_filter :verify_update_permission, only: [:edit, :update]
+  before_filter :verify_destroy_permission, only: [:destroy]
+  before_filter :verify_view_permission, only: [:index]
+
   before_filter :load_lender
 
   def index
@@ -51,6 +56,22 @@ class SubLendersController < ApplicationController
 
   def load_lender
     @lender = Lender.find(params[:lender_id])
+  end
+
+  def verify_create_permission
+    enforce_create_permission(SubLender)
+  end
+
+  def verify_update_permission
+    enforce_update_permission(SubLender)
+  end
+
+  def verify_view_permission
+    enforce_view_permission(SubLender)
+  end
+
+  def verify_destroy_permission
+    enforce_destroy_permission(SubLender)
   end
 
 end

--- a/app/controllers/sub_lenders_controller.rb
+++ b/app/controllers/sub_lenders_controller.rb
@@ -1,0 +1,15 @@
+class SubLendersController < ApplicationController
+
+  before_filter :load_lender
+
+  def index
+    @sub_lenders = @lender.sub_lenders
+  end
+
+  private
+
+  def load_lender
+    @lender = Lender.find(params[:lender_id])
+  end
+
+end

--- a/app/controllers/sub_lenders_controller.rb
+++ b/app/controllers/sub_lenders_controller.rb
@@ -41,6 +41,12 @@ class SubLendersController < ApplicationController
     end
   end
 
+  def destroy
+    @sub_lender = @lender.sub_lenders.find(params[:id])
+    @sub_lender.destroy
+    redirect_to lender_sub_lenders_url(@lender)
+  end
+
   private
 
   def load_lender

--- a/app/exports/loan_report_csv_export.rb
+++ b/app/exports/loan_report_csv_export.rb
@@ -87,7 +87,8 @@ class LoanReportCsvExport < BaseCsvExport
       :cumulative_pre_claim_limit_realised_amount,
       :cumulative_post_claim_limit_realised_amount,
       :scheme,
-      :phase
+      :phase,
+      :sub_lender
     ]
   end
 

--- a/app/exports/loan_report_csv_row.rb
+++ b/app/exports/loan_report_csv_row.rb
@@ -89,6 +89,7 @@ class LoanReportCsvRow
       Money.new(row['cumulative_post_claim_limit_realised_amount'] || 0).to_s,
       scheme_name(row['loan_scheme'], row['loan_source']),
       phase_name(row['lending_limit_phase_id']),
+      row['sub_lender'],
     ]
   end
 

--- a/app/models/admin_audit.rb
+++ b/app/models/admin_audit.rb
@@ -11,6 +11,8 @@ class AdminAudit < ActiveRecord::Base
   LendingLimitActivated = 'Activated Lender Lending limit'
   PhaseCreated = 'Phase created'
   PhaseEdited = 'Phase edited'
+  SubLenderCreated = 'Sub-lender created'
+  SubLenderEdited = 'Sub-lender edited'
   UserCreated = 'User created'
   UserDisabled = 'User disabled'
   UserEdited = 'User edited'

--- a/app/models/change_type.rb
+++ b/app/models/change_type.rb
@@ -18,6 +18,7 @@ class ChangeType < StaticAssociation
     { id: 'g', name: 'Trading Date' },
     { id: 'h', name: 'Company Registration' },
     { id: 'i', name: 'Generic Fields' },
+    { id: 'j', name: 'Sub-lender' },
   ]
 
   BusinessName = find('1')
@@ -38,4 +39,5 @@ class ChangeType < StaticAssociation
   TradingDate = find('g')
   CompanyRegistration = find('h')
   GenericFields = find('i')
+  SubLender = find('j')
 end

--- a/app/models/lender.rb
+++ b/app/models/lender.rb
@@ -65,6 +65,10 @@ class Lender < ActiveRecord::Base
     LenderLogo.new(organisation_reference_code)
   end
 
+  def sub_lender_names
+    @sub_lender_names ||= sub_lenders.map(&:name)
+  end
+
   private
     def current_lending_limit_allocation_for_type(type)
       Money.new(current_lending_limits.where(allocation_type_id: type.id).sum(:allocation))

--- a/app/models/lender.rb
+++ b/app/models/lender.rb
@@ -12,6 +12,7 @@ class Lender < ActiveRecord::Base
   has_many :lender_users
   has_many :loans
   has_many :users, -> { where(type: %w(LenderAdmin LenderUser)) }, class_name: 'User'
+  has_many :sub_lenders
 
   attr_accessible :can_use_add_cap, :name,
     :organisation_reference_code, :primary_contact_email,

--- a/app/models/lender.rb
+++ b/app/models/lender.rb
@@ -66,7 +66,7 @@ class Lender < ActiveRecord::Base
   end
 
   def sub_lender_names
-    @sub_lender_names ||= sub_lenders.map(&:name)
+    @sub_lender_names ||= sub_lenders.pluck(:name)
   end
 
   private

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -323,6 +323,10 @@ class Loan < ActiveRecord::Base
     end
   end
 
+  def sub_lender_names
+    lender.sub_lenders.map(&:name)
+  end
+
   private
 
   def cumulative_realised_amount

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -129,6 +129,7 @@ class Loan < ActiveRecord::Base
   before_create :set_reference
 
   delegate :euro_conversion_rate, :phase, to: :lending_limit
+  delegate :sub_lender_names, to: :lender
   delegate :state_aid_threshold, to: :sic
 
   def self.with_scheme(scheme)
@@ -321,10 +322,6 @@ class Loan < ActiveRecord::Base
     else
       Phase1Rules
     end
-  end
-
-  def sub_lender_names
-    lender.sub_lenders.map(&:name)
   end
 
   private

--- a/app/models/sub_lender.rb
+++ b/app/models/sub_lender.rb
@@ -4,4 +4,7 @@ class SubLender < ActiveRecord::Base
 
   belongs_to :lender
 
+  validates_presence_of :lender_id, strict: true
+  validates_presence_of :name
+
 end

--- a/app/models/sub_lender.rb
+++ b/app/models/sub_lender.rb
@@ -1,0 +1,7 @@
+class SubLender < ActiveRecord::Base
+
+  attr_accessible :name
+
+  belongs_to :lender
+
+end

--- a/app/models/sub_lender.rb
+++ b/app/models/sub_lender.rb
@@ -4,7 +4,7 @@ class SubLender < ActiveRecord::Base
 
   belongs_to :lender
 
-  validates_presence_of :lender_id, strict: true
+  validates_presence_of :lender, strict: true
   validates_presence_of :name
 
 end

--- a/app/permissions/cfe_admin_permissions.rb
+++ b/app/permissions/cfe_admin_permissions.rb
@@ -7,12 +7,15 @@ module CfeAdminPermissions
       LenderAdmin,
       LendingLimit,
       Phase,
-      PremiumCollectorUser
+      PremiumCollectorUser,
+      SubLender,
     ].include?(resource)
   end
 
   def can_destroy?(resource)
-    false
+    [
+      SubLender,
+    ].include?(resource)
   end
 
   def can_update?(resource)
@@ -23,7 +26,8 @@ module CfeAdminPermissions
       LenderAdmin,
       LendingLimit,
       Phase,
-      PremiumCollectorUser
+      PremiumCollectorUser,
+      SubLender,
     ].include?(resource)
   end
 
@@ -48,7 +52,8 @@ module CfeAdminPermissions
       LenderAdmin,
       LendingLimit,
       Phase,
-      PremiumCollectorUser
+      PremiumCollectorUser,
+      SubLender,
     ].include?(resource)
   end
 end

--- a/app/presenters/data_corrections/sub_lender_data_correction.rb
+++ b/app/presenters/data_corrections/sub_lender_data_correction.rb
@@ -1,0 +1,7 @@
+class SubLenderDataCorrection < DataCorrectionPresenter
+  include BasicDataCorrectable
+
+  data_corrects :sub_lender
+
+  delegate :sub_lender_names, to: :loan
+end

--- a/app/presenters/data_corrections/sub_lender_data_correction.rb
+++ b/app/presenters/data_corrections/sub_lender_data_correction.rb
@@ -18,7 +18,7 @@ class SubLenderDataCorrection < DataCorrectionPresenter
   private
 
   def lender_has_sub_lenders?
-    sub_lender_names.present?
+    sub_lender_names.any?
   end
 
   def sub_lender_is_blank

--- a/app/presenters/data_corrections/sub_lender_data_correction.rb
+++ b/app/presenters/data_corrections/sub_lender_data_correction.rb
@@ -7,10 +7,17 @@ class SubLenderDataCorrection < DataCorrectionPresenter
 
   validates_inclusion_of :sub_lender, in: :sub_lender_names, if: :lender_has_sub_lenders?
 
+  validate :sub_lender_is_blank, unless: :lender_has_sub_lenders?
+
   private
 
   def lender_has_sub_lenders?
     sub_lender_names.present?
   end
 
+  def sub_lender_is_blank
+    unless sub_lender.blank?
+      errors.add(:sub_lender, "Must be blank as there are no sub-lenders")
+    end
+  end
 end

--- a/app/presenters/data_corrections/sub_lender_data_correction.rb
+++ b/app/presenters/data_corrections/sub_lender_data_correction.rb
@@ -9,6 +9,12 @@ class SubLenderDataCorrection < DataCorrectionPresenter
 
   validate :sub_lender_is_blank, unless: :lender_has_sub_lenders?
 
+  def no_sub_lenders_hint
+    unless lender_has_sub_lenders?
+      "There are no sub-lenders for this loan's lender. If you wish to remove the existing sub-lender from this loan, submit this form with a blank selection."
+    end
+  end
+
   private
 
   def lender_has_sub_lenders?

--- a/app/presenters/data_corrections/sub_lender_data_correction.rb
+++ b/app/presenters/data_corrections/sub_lender_data_correction.rb
@@ -1,7 +1,16 @@
 class SubLenderDataCorrection < DataCorrectionPresenter
   include BasicDataCorrectable
 
-  data_corrects :sub_lender
+  data_corrects :sub_lender, skip_validation: true
 
   delegate :sub_lender_names, to: :loan
+
+  validates_inclusion_of :sub_lender, in: :sub_lender_names, if: :lender_has_sub_lenders?
+
+  private
+
+  def lender_has_sub_lenders?
+    sub_lender_names.present?
+  end
+
 end

--- a/app/presenters/loan_entry.rb
+++ b/app/presenters/loan_entry.rb
@@ -69,7 +69,7 @@ class LoanEntry
   validate :repayment_frequency_allowed
   validate :company_turnover_is_allowed, if: :turnover
   validates_acceptance_of :state_aid_is_valid, allow_nil: false, accept: true
-  validates_inclusion_of :sub_lender, in: :sub_lender_names, if: -> { sub_lender_names.present? }
+  validates_inclusion_of :sub_lender, in: :sub_lender_names, if: -> { sub_lender_names.any? }
 
   validate do
     errors.add(:declaration_signed, :accepted) unless self.declaration_signed

--- a/app/presenters/loan_entry.rb
+++ b/app/presenters/loan_entry.rb
@@ -54,6 +54,7 @@ class LoanEntry
   attribute :invoice_discount_limit
   attribute :debtor_book_coverage
   attribute :debtor_book_topup
+  attribute :sub_lender
 
   delegate :calculate_state_aid, :reason, :sic, to: :loan
 
@@ -67,6 +68,7 @@ class LoanEntry
   validate :repayment_frequency_allowed
   validate :company_turnover_is_allowed, if: :turnover
   validates_acceptance_of :state_aid_is_valid, allow_nil: false, accept: true
+  validates_presence_of :sub_lender, if: :sub_lender_required?
 
   validate do
     errors.add(:declaration_signed, :accepted) unless self.declaration_signed
@@ -90,6 +92,14 @@ class LoanEntry
 
   def total_prepayment
     (debtor_book_coverage || 0) + (debtor_book_topup || 0)
+  end
+
+  def sub_lender_required?
+    sub_lender_names.present?
+  end
+
+  def sub_lender_names
+    lender.sub_lenders.map(&:name)
   end
 
   private

--- a/app/presenters/loan_entry.rb
+++ b/app/presenters/loan_entry.rb
@@ -57,6 +57,7 @@ class LoanEntry
   attribute :sub_lender
 
   delegate :calculate_state_aid, :reason, :sic, to: :loan
+  delegate :sub_lender_names, to: :lender
 
   validates_presence_of :business_name, :fees, :interest_rate,
     :interest_rate_type_id, :legal_form_id, :repayment_frequency_id
@@ -68,7 +69,7 @@ class LoanEntry
   validate :repayment_frequency_allowed
   validate :company_turnover_is_allowed, if: :turnover
   validates_acceptance_of :state_aid_is_valid, allow_nil: false, accept: true
-  validates_presence_of :sub_lender, if: :sub_lender_required?
+  validates_inclusion_of :sub_lender, in: :sub_lender_names, if: -> { sub_lender_names.present? }
 
   validate do
     errors.add(:declaration_signed, :accepted) unless self.declaration_signed
@@ -92,14 +93,6 @@ class LoanEntry
 
   def total_prepayment
     (debtor_book_coverage || 0) + (debtor_book_topup || 0)
-  end
-
-  def sub_lender_required?
-    sub_lender_names.present?
-  end
-
-  def sub_lender_names
-    lender.sub_lenders.map(&:name)
   end
 
   private

--- a/app/presenters/loan_transfer/base.rb
+++ b/app/presenters/loan_transfer/base.rb
@@ -54,12 +54,13 @@ class LoanTransfer::Base
         maturity_date
         invoice_id
         lender_reference
+        sub_lender
       ).each do |field|
         new_loan.public_send("#{field}=", nil)
       end
 
       (1..5).each do |num|
-        new_loan.send("generic#{num}=", nil)
+        new_loan.public_send("generic#{num}=", nil)
       end
 
       yield new_loan if block_given?

--- a/app/presenters/transferred_loan_entry.rb
+++ b/app/presenters/transferred_loan_entry.rb
@@ -33,16 +33,18 @@ class TransferredLoanEntry
   attribute :repayment_duration
   attribute :repayment_frequency_id
   attribute :state_aid
+  attribute :sub_lender
   attribute :generic1
   attribute :generic2
   attribute :generic3
   attribute :generic4
   attribute :generic5
 
+  delegate :sub_lender_names, to: :lender
+
   validates_presence_of :amount, :repayment_duration, :repayment_frequency_id
-
+  validates_inclusion_of :sub_lender, in: :sub_lender_names, if: -> { sub_lender_names.present? }
   validate :repayment_frequency_allowed
-
 
   validate do
     errors.add(:declaration_signed, :accepted) unless self.declaration_signed

--- a/app/presenters/transferred_loan_entry.rb
+++ b/app/presenters/transferred_loan_entry.rb
@@ -43,7 +43,7 @@ class TransferredLoanEntry
   delegate :sub_lender_names, to: :lender
 
   validates_presence_of :amount, :repayment_duration, :repayment_frequency_id
-  validates_inclusion_of :sub_lender, in: :sub_lender_names, if: -> { sub_lender_names.present? }
+  validates_inclusion_of :sub_lender, in: :sub_lender_names, if: -> { sub_lender_names.any? }
   validate :repayment_frequency_allowed
 
   validate do

--- a/app/views/data_corrections/_sub_lender.html.erb
+++ b/app/views/data_corrections/_sub_lender.html.erb
@@ -1,0 +1,2 @@
+<%= simple_form_row 'Sub-lender', @loan.sub_lender %>
+<%= f.input :sub_lender, label: 'New Sub-lender', as: :select, collection: @loan.sub_lender_names %>

--- a/app/views/data_corrections/_sub_lender.html.erb
+++ b/app/views/data_corrections/_sub_lender.html.erb
@@ -1,2 +1,2 @@
 <%= simple_form_row 'Sub-lender', @loan.sub_lender %>
-<%= f.input :sub_lender, label: 'New Sub-lender', as: :select, collection: @loan.sub_lender_names %>
+<%= f.input :sub_lender, label: 'New Sub-lender', as: :select, collection: @loan.sub_lender_names, hint: @presenter.no_sub_lenders_hint %>

--- a/app/views/data_corrections/index.html.erb
+++ b/app/views/data_corrections/index.html.erb
@@ -9,7 +9,11 @@
 <ul>
   <li><%= link_to('Business Name', new_loan_data_correction_path(@loan, type: 'business_name')) %></li>
   <li><%= link_to('Company Registration', new_loan_data_correction_path(@loan, type: 'company_registration')) %></li>
-  <% if @loan.state == Loan::Demanded %><li><%= link_to('Demanded Amount', new_loan_data_correction_path(@loan, type: 'demanded_amount')) %></li><% end %>
+
+  <% if @loan.state == Loan::Demanded %>
+    <li><%= link_to('Demanded Amount', new_loan_data_correction_path(@loan, type: 'demanded_amount')) %></li>
+  <% end %>
+
   <li><%= link_to('Generic Fields', new_loan_data_correction_path(@loan, type: 'generic_fields')) %></li>
   <li><%= link_to('Lender Reference', new_loan_data_correction_path(@loan, type: 'lender_reference')) %></li>
   <li><%= link_to('Postcode', new_loan_data_correction_path(@loan, type: 'postcode')) %></li>

--- a/app/views/data_corrections/index.html.erb
+++ b/app/views/data_corrections/index.html.erb
@@ -16,4 +16,5 @@
   <li><%= link_to('Sortcode', new_loan_data_correction_path(@loan, type: 'sortcode')) %></li>
   <li><%= link_to('Trading Date', new_loan_data_correction_path(@loan, type: 'trading_date')) %></li>
   <li><%= link_to('Trading Name', new_loan_data_correction_path(@loan, type: 'trading_name')) %></li>
+  <li><%= link_to('Sub-lender', new_loan_data_correction_path(@loan, type: 'sub_lender')) %></li>
 </ul>

--- a/app/views/data_corrections/index.html.erb
+++ b/app/views/data_corrections/index.html.erb
@@ -16,5 +16,8 @@
   <li><%= link_to('Sortcode', new_loan_data_correction_path(@loan, type: 'sortcode')) %></li>
   <li><%= link_to('Trading Date', new_loan_data_correction_path(@loan, type: 'trading_date')) %></li>
   <li><%= link_to('Trading Name', new_loan_data_correction_path(@loan, type: 'trading_name')) %></li>
-  <li><%= link_to('Sub-lender', new_loan_data_correction_path(@loan, type: 'sub_lender')) %></li>
+
+  <% unless @loan.sub_lender_names.empty? && @loan.sub_lender.blank? %>
+    <li><%= link_to('Sub-lender', new_loan_data_correction_path(@loan, type: 'sub_lender')) %></li>
+  <% end %>
 </ul>

--- a/app/views/data_corrections/index.html.erb
+++ b/app/views/data_corrections/index.html.erb
@@ -17,7 +17,7 @@
   <li><%= link_to('Trading Date', new_loan_data_correction_path(@loan, type: 'trading_date')) %></li>
   <li><%= link_to('Trading Name', new_loan_data_correction_path(@loan, type: 'trading_name')) %></li>
 
-  <% unless @loan.sub_lender_names.empty? && @loan.sub_lender.blank? %>
+  <% if @loan.sub_lender.present? || @loan.sub_lender_names.any? %>
     <li><%= link_to('Sub-lender', new_loan_data_correction_path(@loan, type: 'sub_lender')) %></li>
   <% end %>
 </ul>

--- a/app/views/data_corrections/index.html.erb
+++ b/app/views/data_corrections/index.html.erb
@@ -14,10 +14,11 @@
   <li><%= link_to('Lender Reference', new_loan_data_correction_path(@loan, type: 'lender_reference')) %></li>
   <li><%= link_to('Postcode', new_loan_data_correction_path(@loan, type: 'postcode')) %></li>
   <li><%= link_to('Sortcode', new_loan_data_correction_path(@loan, type: 'sortcode')) %></li>
-  <li><%= link_to('Trading Date', new_loan_data_correction_path(@loan, type: 'trading_date')) %></li>
-  <li><%= link_to('Trading Name', new_loan_data_correction_path(@loan, type: 'trading_name')) %></li>
 
   <% if @loan.sub_lender.present? || @loan.sub_lender_names.any? %>
     <li><%= link_to('Sub-lender', new_loan_data_correction_path(@loan, type: 'sub_lender')) %></li>
   <% end %>
+
+  <li><%= link_to('Trading Date', new_loan_data_correction_path(@loan, type: 'trading_date')) %></li>
+  <li><%= link_to('Trading Name', new_loan_data_correction_path(@loan, type: 'trading_name')) %></li>
 </ul>

--- a/app/views/lenders/index.html.erb
+++ b/app/views/lenders/index.html.erb
@@ -21,6 +21,7 @@
       <th></th>
       <th></th>
       <th></th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -34,6 +35,7 @@
         <td><%= link_to 'Expert Users', lender_lender_experts_path(lender) %></td>
         <td><%= link_to 'Lender Admins', lender_lender_admins_path(lender) %></td>
         <td><%= link_to 'Lending Limits', lender_lending_limits_path(lender) %></td>
+        <td><%= link_to 'Sub-lenders', lender_sub_lenders_path(lender) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/loan_entries/new.html.erb
+++ b/app/views/loan_entries/new.html.erb
@@ -93,6 +93,7 @@
     <%= f.input :would_you_lend, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
     <%= f.input :collateral_exhausted, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
     <%= f.input :not_insolvent, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
+    <%= f.input(:sub_lender, as: :select, collection: @loan_entry.sub_lender_names) if @loan_entry.sub_lender_required?%>
     <%= f.input :generic1, as: :string %>
     <%= f.input :generic2, as: :string %>
     <%= f.input :generic3, as: :string %>

--- a/app/views/loan_entries/new.html.erb
+++ b/app/views/loan_entries/new.html.erb
@@ -93,7 +93,7 @@
     <%= f.input :would_you_lend, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
     <%= f.input :collateral_exhausted, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
     <%= f.input :not_insolvent, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
-    <%= f.input(:sub_lender, as: :select, collection: @loan_entry.sub_lender_names) if @loan_entry.sub_lender_names.present? %>
+    <%= f.input(:sub_lender, as: :select, collection: @loan_entry.sub_lender_names) if @loan_entry.sub_lender_names.any? %>
     <%= f.input :generic1, as: :string %>
     <%= f.input :generic2, as: :string %>
     <%= f.input :generic3, as: :string %>

--- a/app/views/loan_entries/new.html.erb
+++ b/app/views/loan_entries/new.html.erb
@@ -93,7 +93,7 @@
     <%= f.input :would_you_lend, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
     <%= f.input :collateral_exhausted, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
     <%= f.input :not_insolvent, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
-    <%= f.input(:sub_lender, as: :select, collection: @loan_entry.sub_lender_names) if @loan_entry.sub_lender_required?%>
+    <%= f.input(:sub_lender, as: :select, collection: @loan_entry.sub_lender_names) if @loan_entry.sub_lender_names.present? %>
     <%= f.input :generic1, as: :string %>
     <%= f.input :generic2, as: :string %>
     <%= f.input :generic3, as: :string %>

--- a/app/views/loans/details.html.erb
+++ b/app/views/loans/details.html.erb
@@ -17,6 +17,11 @@
 <h3>Eligibility and Loan Entry</h3>
 <%= loan_details_table(@loan, 'simple_form.labels.loan_entry') do |table| %>
   <%= table.row 'lender', header: 'What is the name of the lender organisation?' %>
+
+  <% if @loan.sub_lender? %>
+    <%= table.row 'sub_lender', header: 'Sub-lender' %>
+  <% end %>
+
   <%= table.row 'reference', header: 'System Generated Identification Reference' %>
   <%= table.row 'lender_reference' %>
   <%= table.row 'declaration_signed' %>

--- a/app/views/sub_lenders/_form.html.erb
+++ b/app/views/sub_lenders/_form.html.erb
@@ -1,0 +1,9 @@
+<%= simple_form_for [@lender, @sub_lender], html: { class: 'form-horizontal form-sub-lender' } do |f| %>
+
+  <%= f.input :name %>
+
+  <div class="form-actions">
+    <%= f.button :submit, class: 'btn btn-primary', value: @sub_lender.new_record? ? 'Create Sub-lender' : 'Update Sub-lender', data: { 'disable-with' => 'Submitting...' } %>
+  </div>
+
+<% end %>

--- a/app/views/sub_lenders/edit.html.erb
+++ b/app/views/sub_lenders/edit.html.erb
@@ -1,0 +1,11 @@
+<%= breadcrumbs(
+  link_to('Lenders', lenders_path),
+  h(@lender.name),
+  link_to('Sub-lenders', lender_sub_lenders_path(@lender))
+) %>
+
+<div class="page-header">
+  <h1>Edit Sub-lender for <%= @lender.name %></h1>
+</div>
+
+<%= render 'form' %>

--- a/app/views/sub_lenders/index.html.erb
+++ b/app/views/sub_lenders/index.html.erb
@@ -16,12 +16,14 @@
     <thead>
       <tr>
         <th>Sub-lender Name</th>
+        <th>Options</th>
       </tr>
     </thead>
     <tbody>
       <% @sub_lenders.each do |sub_lender| %>
         <tr>
           <td><%= link_to sub_lender.name, edit_lender_sub_lender_path(@lender, sub_lender) %></td>
+          <td><%= link_to "Delete", lender_sub_lender_path(@lender, sub_lender), data: {confirm: "Are you sure?"}, method: :delete %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/sub_lenders/index.html.erb
+++ b/app/views/sub_lenders/index.html.erb
@@ -1,0 +1,33 @@
+<%= breadcrumbs(
+  link_to('Lenders', lenders_path),
+  h(@lender.name)
+) %>
+
+<div class="page-header">
+  <h1>View Sub-lender</h1>
+</div>
+
+<div class="actions">
+  <%= link_to %{<i class="icon-plus"></i> New Sub-lender}.html_safe, new_lender_sub_lender_path(@lender), class: 'btn' %>
+</div>
+
+<% unless @sub_lenders.empty? %>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Sub-lender Name</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @sub_lenders.each do |sub_lender| %>
+        <tr>
+          <td><%= link_to sub_lender.name, edit_lender_sub_lender_path(@lender, sub_lender) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>
+    There are no sub-lenders for <%= @lender.name %>. <%= link_to "Add one now", new_lender_sub_lender_path(@lender) %>.
+  </p>
+<% end %>

--- a/app/views/sub_lenders/new.html.erb
+++ b/app/views/sub_lenders/new.html.erb
@@ -1,0 +1,11 @@
+<%= breadcrumbs(
+  link_to('Lenders', lenders_path),
+  h(@lender.name),
+  link_to('Sub-lenders', lender_sub_lenders_path(@lender))
+) %>
+
+<div class="page-header">
+  <h1>Add Sub-lender for <%= @lender.name %></h1>
+</div>
+
+<%= render 'form' %>

--- a/app/views/transferred_loan_entries/new.html.erb
+++ b/app/views/transferred_loan_entries/new.html.erb
@@ -78,7 +78,7 @@ Please note that all the information within Facility Entry can be revised, howev
       <%= f.input :viable_proposition, as: :radio_buttons, disabled: true, wrapper_html: {class: 'radio-buttons-inline'} %>
       <%= f.input :would_you_lend, as: :radio_buttons, disabled: true, wrapper_html: {class: 'radio-buttons-inline'} %>
       <%= f.input :collateral_exhausted, as: :radio_buttons, disabled: true, wrapper_html: {class: 'radio-buttons-inline'} %>
-      <%= f.input(:sub_lender, as: :select, collection: @transferred_loan_entry.sub_lender_names) if @transferred_loan_entry.sub_lender_names.present? %>
+      <%= f.input(:sub_lender, as: :select, collection: @transferred_loan_entry.sub_lender_names) if @transferred_loan_entry.sub_lender_names.any? %>
       <%= f.input :generic1, as: :string %>
       <%= f.input :generic2, as: :string %>
       <%= f.input :generic3, as: :string %>

--- a/app/views/transferred_loan_entries/new.html.erb
+++ b/app/views/transferred_loan_entries/new.html.erb
@@ -78,6 +78,7 @@ Please note that all the information within Facility Entry can be revised, howev
       <%= f.input :viable_proposition, as: :radio_buttons, disabled: true, wrapper_html: {class: 'radio-buttons-inline'} %>
       <%= f.input :would_you_lend, as: :radio_buttons, disabled: true, wrapper_html: {class: 'radio-buttons-inline'} %>
       <%= f.input :collateral_exhausted, as: :radio_buttons, disabled: true, wrapper_html: {class: 'radio-buttons-inline'} %>
+      <%= f.input(:sub_lender, as: :select, collection: @transferred_loan_entry.sub_lender_names) if @transferred_loan_entry.sub_lender_names.present? %>
       <%= f.input :generic1, as: :string %>
       <%= f.input :generic2, as: :string %>
       <%= f.input :generic3, as: :string %>

--- a/config/locales/csv_headers.en.yml
+++ b/config/locales/csv_headers.en.yml
@@ -84,6 +84,7 @@ en:
       cumulative_post_claim_limit_realised_amount: Cumulative Value of All Post-Claim Limit Realisations
       scheme: Scheme
       phase: Phase
+      sub_lender: Sub-lender
 
     loan_audit_report:
       loan_reference: Loan reference

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,6 +139,8 @@ en:
             maturity_date:
               required: "can't be blank"
               greater_than_max_repayment_duration: Maturity date must not be more than than ten years (or 2 years for Type E and 3 years for Type F loans) after the date of initial draw of funds
+            sub_lender:
+              inclusion: "a sub-lender must be chosen"
         premium_schedule_report:
           attributes:
             base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,8 @@ en:
             maturity_date:
               less_than_min_repayment_duration: Maturity date must be at least three months after the date of initial draw of funds
               greater_than_max_repayment_duration: Maturity date must not be more than than ten years (or 2 years for Type E and 3 years for Type F loans) after the date of initial draw of funds
+            sub_lender:
+              blank: "a sub-lender must be chosen"
             turnover:
               <<: *turnover
         loan_offer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,7 @@ en:
               less_than_min_repayment_duration: Maturity date must be at least three months after the date of initial draw of funds
               greater_than_max_repayment_duration: Maturity date must not be more than than ten years (or 2 years for Type E and 3 years for Type F loans) after the date of initial draw of funds
             sub_lender:
-              blank: "a sub-lender must be chosen"
+              inclusion: "a sub-lender must be chosen"
             turnover:
               <<: *turnover
         loan_offer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,10 @@ en:
           attributes:
             expert_users:
               must_have_at_least_one_email: 'must have at least one email address'
+        data_correction:
+          attributes:
+            sub_lender:
+              inclusion: "a sub-lender must be chosen"
         loan_change:
           attributes:
             added_months:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -75,6 +75,7 @@ en:
         postcode: "What is the postcode of the Applicant's main business address? (In instances where the Applicant's postcode is not available please enter the lender's branch postcode)."
         sortcode: '(For banks only) What is the Sort Code of the bank branch or business centre which originated this application? (nnnnnn)'
         repayment_frequency_id: "At what frequency will the Applicant make repayments of the principal of the facility? (Note: Type E, F, G & H facilities should be input as Interest Only unless there is to be a structured repayment of the facility principal over the period the guarantee is to be in place.)"
+        sub_lender: "Sub-lender"
         generic1: Enter any lender specific information to be captured for this application. (For optional internal use). Field 1.
         generic2: Enter any lender specific information to be captured for this application. (For optional internal use). Field 2.
         generic3: Enter any lender specific information to be captured for this application. (For optional internal use). Field 3.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ EFG::Application.routes.draw do
       end
     end
 
+    resources :sub_lenders, except: [:show]
+
     with_options only: [:index, :show, :new, :create, :edit, :update] do
       %w(lender_admins lender_users).each do |resource|
         resources resource do

--- a/db/migrate/20150115162401_create_sub_lenders.rb
+++ b/db/migrate/20150115162401_create_sub_lenders.rb
@@ -1,0 +1,11 @@
+class CreateSubLenders < ActiveRecord::Migration
+  def change
+    create_table :sub_lenders do |t|
+      t.belongs_to :lender, null: false
+      t.string :name
+      t.timestamps
+    end
+
+    add_index :sub_lenders, :lender_id
+  end
+end

--- a/db/migrate/20150123115521_add_sub_lender_to_loans.rb
+++ b/db/migrate/20150123115521_add_sub_lender_to_loans.rb
@@ -1,0 +1,5 @@
+class AddSubLenderToLoans < ActiveRecord::Migration
+  def change
+    add_column :loans, :sub_lender, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -531,6 +531,15 @@ ActiveRecord::Schema.define(version: 20150401125109) do
 
   add_index "sic_codes", ["code"], name: "index_sic_codes_on_code", unique: true, using: :btree
 
+  create_table "sub_lenders", force: true do |t|
+    t.integer  "lender_id",  null: false
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sub_lenders", ["lender_id"], name: "index_sub_lenders_on_lender_id", using: :btree
+
   create_table "user_audits", force: true do |t|
     t.integer  "user_id"
     t.string   "legacy_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -401,6 +401,7 @@ ActiveRecord::Schema.define(version: 20150401125109) do
     t.boolean  "not_insolvent"
     t.decimal  "euro_conversion_rate",                           precision: 17, scale: 14
     t.integer  "loan_sub_category_id"
+    t.string   "sub_lender"
   end
 
   add_index "loans", ["legacy_id"], name: "index_loans_on_legacy_id", unique: true, using: :btree

--- a/spec/controllers/sub_lenders_controller_spec.rb
+++ b/spec/controllers/sub_lenders_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe SubLendersController do
+  let(:lender) { FactoryGirl.create(:lender) }
+
+  describe 'GET index' do
+    def dispatch
+      get :index, lender_id: lender.id
+    end
+
+    it_behaves_like 'AuditorUser-restricted controller'
+    it_behaves_like 'CfeUser-restricted controller'
+    it_behaves_like 'LenderAdmin-restricted controller'
+    it_behaves_like 'LenderUser-restricted controller'
+    it_behaves_like 'PremiumCollectorUser-restricted controller'
+  end
+
+  describe 'GET new' do
+    def dispatch
+      get :new, lender_id: lender.id
+    end
+
+    it_behaves_like 'AuditorUser-restricted controller'
+    it_behaves_like 'CfeUser-restricted controller'
+    it_behaves_like 'LenderAdmin-restricted controller'
+    it_behaves_like 'LenderUser-restricted controller'
+    it_behaves_like 'PremiumCollectorUser-restricted controller'
+  end
+
+  describe 'POST create' do
+    def dispatch
+      post :create, lender_id: lender.id
+    end
+
+    it_behaves_like 'AuditorUser-restricted controller'
+    it_behaves_like 'CfeUser-restricted controller'
+    it_behaves_like 'LenderAdmin-restricted controller'
+    it_behaves_like 'LenderUser-restricted controller'
+    it_behaves_like 'PremiumCollectorUser-restricted controller'
+  end
+
+  describe 'GET edit' do
+    let(:sub_lender) { FactoryGirl.create(:sub_lender, lender: lender) }
+
+    def dispatch
+      get :edit, lender_id: lender.id, id: sub_lender.id
+    end
+
+    it_behaves_like 'AuditorUser-restricted controller'
+    it_behaves_like 'CfeUser-restricted controller'
+    it_behaves_like 'LenderAdmin-restricted controller'
+    it_behaves_like 'LenderUser-restricted controller'
+    it_behaves_like 'PremiumCollectorUser-restricted controller'
+  end
+
+  describe 'PUT update' do
+    let(:sub_lender) { FactoryGirl.create(:sub_lender, lender: lender) }
+
+    def dispatch
+      put :update, { lender_id: lender.id, id: sub_lender.id, sub_lender: { name: 'foo' } }
+    end
+
+    it_behaves_like 'AuditorUser-restricted controller'
+    it_behaves_like 'CfeUser-restricted controller'
+    it_behaves_like 'LenderAdmin-restricted controller'
+    it_behaves_like 'LenderUser-restricted controller'
+    it_behaves_like 'PremiumCollectorUser-restricted controller'
+  end
+
+  describe 'DELETE destroy' do
+    let(:sub_lender) { FactoryGirl.create(:sub_lender, lender: lender) }
+
+    def dispatch
+      delete :destroy, lender_id: lender.id, id: sub_lender.id
+    end
+
+    it_behaves_like 'AuditorUser-restricted controller'
+    it_behaves_like 'CfeUser-restricted controller'
+    it_behaves_like 'LenderAdmin-restricted controller'
+    it_behaves_like 'LenderUser-restricted controller'
+    it_behaves_like 'PremiumCollectorUser-restricted controller'
+  end
+
+end

--- a/spec/exports/loan_report_csv_export_spec.rb
+++ b/spec/exports/loan_report_csv_export_spec.rb
@@ -152,6 +152,7 @@ describe LoanReportCsvExport do
         debtor_book_coverage: 30,
         debtor_book_topup: 5,
         lender_reference: 'lenderref1',
+        sub_lender: 'Sub-lender 1'
       )
     }
 
@@ -244,6 +245,7 @@ describe LoanReportCsvExport do
           :cumulative_post_claim_limit_realised_amount,
           :scheme,
           :phase,
+          :sub_lender,
         ].map {|h| t(h) }
     end
 
@@ -331,6 +333,7 @@ describe LoanReportCsvExport do
       row[t(:cumulative_post_claim_limit_realised_amount)].should == '2000.00'
       row[t(:scheme)].should == 'EFG'
       row[t(:phase)].should == 'Phase 5 (FY 2013/14)'
+      row[t(:sub_lender)].should == 'Sub-lender 1'
     end
 
     context "without guarantee rate on loan" do
@@ -351,7 +354,7 @@ describe LoanReportCsvExport do
       it "exports phase's premium rate" do
         row[t(:premium_rate)].should == '2.0'
       end
-    end  
+    end
   end
 
   private

--- a/spec/factories/data_correction_presenter_factory.rb
+++ b/spec/factories/data_correction_presenter_factory.rb
@@ -46,5 +46,9 @@ FactoryGirl.define do
     factory :sortcode_data_correction, class: SortcodeDataCorrection do
       sortcode '123456'
     end
+
+    factory :sub_lender_data_correction, class: SubLenderDataCorrection do
+      sub_lender 'ACME sub lender'
+    end
   end
 end

--- a/spec/factories/loan_factory.rb
+++ b/spec/factories/loan_factory.rb
@@ -198,6 +198,10 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_sub_lender do
+      sub_lender "ACME sub-lender"
+    end
+
     trait :efg do
       loan_scheme Loan::EFG_SCHEME
       loan_source Loan::SFLG_SOURCE

--- a/spec/factories/sub_lender_factory.rb
+++ b/spec/factories/sub_lender_factory.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :sub_lender do
+    lender
     sequence(:name) { |n| "Sub-lender #{n}" }
   end
 end

--- a/spec/factories/sub_lender_factory.rb
+++ b/spec/factories/sub_lender_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :sub_lender do
+    sequence(:name) { |n| "Sub-lender #{n}" }
+  end
+end

--- a/spec/models/sub_lender_spec.rb
+++ b/spec/models/sub_lender_spec.rb
@@ -1,5 +1,25 @@
 require 'spec_helper'
 
 describe SubLender do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  describe 'validations' do
+    let(:sub_lender) { FactoryGirl.build(:sub_lender) }
+
+    it 'has a valid Factory' do
+      sub_lender.should be_valid
+    end
+
+    it 'strictly requires a lender' do
+      expect {
+        sub_lender.lender = nil
+        sub_lender.valid?
+      }.to raise_error(ActiveModel::StrictValidationFailed)
+    end
+
+    it 'requires a name' do
+      sub_lender.name = ''
+      sub_lender.should_not be_valid
+    end
+  end
+
 end

--- a/spec/models/sub_lender_spec.rb
+++ b/spec/models/sub_lender_spec.rb
@@ -6,7 +6,7 @@ describe SubLender do
     let(:sub_lender) { FactoryGirl.build(:sub_lender) }
 
     it 'has a valid Factory' do
-      sub_lender.should be_valid
+      expect(sub_lender).to be_valid
     end
 
     it 'strictly requires a lender' do
@@ -18,7 +18,7 @@ describe SubLender do
 
     it 'requires a name' do
       sub_lender.name = ''
-      sub_lender.should_not be_valid
+      expect(sub_lender).not_to be_valid
     end
   end
 

--- a/spec/models/sub_lender_spec.rb
+++ b/spec/models/sub_lender_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe SubLender do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/permissions/auditor_user_permissions_spec.rb
+++ b/spec/permissions/auditor_user_permissions_spec.rb
@@ -259,4 +259,11 @@ describe AuditorUserPermissions do
     it { refute user.can_update?(AgreedDraw) }
     it { refute user.can_view?(AgreedDraw) }
   end
+
+  context 'SubLender' do
+    it { refute user.can_create?(SubLender) }
+    it { refute user.can_update?(SubLender) }
+    it { refute user.can_view?(SubLender) }
+    it { refute user.can_destroy?(SubLender) }
+  end
 end

--- a/spec/permissions/cfe_admin_permissions_spec.rb
+++ b/spec/permissions/cfe_admin_permissions_spec.rb
@@ -259,4 +259,11 @@ describe CfeAdminPermissions do
     it { refute user.can_update?(AgreedDraw) }
     it { refute user.can_view?(AgreedDraw) }
   end
+
+  context 'SubLender' do
+    it { assert user.can_create?(SubLender) }
+    it { assert user.can_update?(SubLender) }
+    it { assert user.can_view?(SubLender) }
+    it { assert user.can_destroy?(SubLender) }
+  end
 end

--- a/spec/permissions/cfe_user_permissions_spec.rb
+++ b/spec/permissions/cfe_user_permissions_spec.rb
@@ -259,4 +259,11 @@ describe CfeUserPermissions do
     it { refute user.can_update?(AgreedDraw) }
     it { refute user.can_view?(AgreedDraw) }
   end
+
+  context 'SubLender' do
+    it { refute user.can_create?(SubLender) }
+    it { refute user.can_update?(SubLender) }
+    it { refute user.can_view?(SubLender) }
+    it { refute user.can_destroy?(SubLender) }
+  end
 end

--- a/spec/permissions/lender_admin_permissions_spec.rb
+++ b/spec/permissions/lender_admin_permissions_spec.rb
@@ -283,4 +283,11 @@ describe LenderAdminPermissions do
     it { refute user.can_update?(AgreedDraw) }
     it { refute user.can_view?(AgreedDraw) }
   end
+
+  context 'SubLender' do
+    it { refute user.can_create?(SubLender) }
+    it { refute user.can_update?(SubLender) }
+    it { refute user.can_view?(SubLender) }
+    it { refute user.can_destroy?(SubLender) }
+  end
 end

--- a/spec/permissions/lender_user_permissions_spec.rb
+++ b/spec/permissions/lender_user_permissions_spec.rb
@@ -283,4 +283,11 @@ describe LenderUserPermissions do
     it { refute user.can_update?(AgreedDraw) }
     it { refute user.can_view?(AgreedDraw) }
   end
+
+  context 'SubLender' do
+    it { refute user.can_create?(SubLender) }
+    it { refute user.can_update?(SubLender) }
+    it { refute user.can_view?(SubLender) }
+    it { refute user.can_destroy?(SubLender) }
+  end
 end

--- a/spec/permissions/premium_collector_user_permissions_spec.rb
+++ b/spec/permissions/premium_collector_user_permissions_spec.rb
@@ -259,4 +259,11 @@ describe PremiumCollectorUser do
     it { refute user.can_update?(AgreedDraw) }
     it { refute user.can_view?(AgreedDraw) }
   end
+
+  context 'SubLender' do
+    it { refute user.can_create?(SubLender) }
+    it { refute user.can_update?(SubLender) }
+    it { refute user.can_view?(SubLender) }
+    it { refute user.can_destroy?(SubLender) }
+  end
 end

--- a/spec/permissions/super_user_permissions_spec.rb
+++ b/spec/permissions/super_user_permissions_spec.rb
@@ -253,4 +253,11 @@ describe SuperUserPermissions do
     it { refute user.can_update?(AgreedDraw) }
     it { refute user.can_view?(AgreedDraw) }
   end
+
+  context 'SubLender' do
+    it { refute user.can_create?(SubLender) }
+    it { refute user.can_update?(SubLender) }
+    it { refute user.can_view?(SubLender) }
+    it { refute user.can_destroy?(SubLender) }
+  end
 end

--- a/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
+++ b/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
@@ -12,14 +12,14 @@ describe SubLenderDataCorrection do
 
     it "must have a sub-lender" do
       data_correction.sub_lender = nil
-      data_correction.should_not be_valid
-      data_correction.should have(1).error_on(:sub_lender)
+      expect(data_correction).not_to be_valid
+      expect(data_correction).to have(1).error_on(:sub_lender)
     end
 
     it "must have an allowed sub-lender" do
       data_correction.sub_lender = "not a valid sub lender for this lender"
-      data_correction.should_not be_valid
-      data_correction.should have(1).error_on(:sub_lender)
+      expect(data_correction).not_to be_valid
+      expect(data_correction).to have(1).error_on(:sub_lender)
     end
   end
 
@@ -28,8 +28,8 @@ describe SubLenderDataCorrection do
 
     it "must have a blank sub_lender" do
       data_correction.sub_lender = 'ACME Sub-lender'
-      data_correction.should_not be_valid
-      data_correction.should have(1).error_on(:sub_lender)
+      expect(data_correction).not_to be_valid
+      expect(data_correction).to have(1).error_on(:sub_lender)
     end
   end
 end

--- a/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
+++ b/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
@@ -1,5 +1,25 @@
 require 'spec_helper'
 
 describe SubLenderDataCorrection do
-  it_behaves_like 'a basic data correction presenter', :sub_lender, 'Bar'
+  let(:current_user) { FactoryGirl.create(:lender_user) }
+  let(:data_correction) { FactoryGirl.build(:sub_lender_data_correction, loan: loan, created_by: current_user) }
+
+  context "when lender has sub-lenders" do
+    let!(:loan) { FactoryGirl.create(:loan, :guaranteed, lender: current_user.lender) }
+    let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: loan.lender, name: 'ACME Sub-lender') }
+
+    it_behaves_like 'loan updating data correction presenter', :sub_lender, 'ACME Sub-lender'
+
+    it "must have a sub-lender" do
+      data_correction.sub_lender = nil
+      data_correction.should_not be_valid
+      data_correction.should have(1).error_on(:sub_lender)
+    end
+
+    it "must have an allowed sub-lender" do
+      data_correction.sub_lender = "not a valid sub lender for this lender"
+      data_correction.should_not be_valid
+      data_correction.should have(1).error_on(:sub_lender)
+    end
+  end
 end

--- a/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
+++ b/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe SubLenderDataCorrection do
+  it_behaves_like 'a basic data correction presenter', :sub_lender, 'Bar'
+end

--- a/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
+++ b/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
@@ -22,4 +22,14 @@ describe SubLenderDataCorrection do
       data_correction.should have(1).error_on(:sub_lender)
     end
   end
+
+  context "when lender has no sub-lenders" do
+    let!(:loan) { FactoryGirl.create(:loan, :guaranteed, lender: current_user.lender) }
+
+    it "must have a blank sub_lender" do
+      data_correction.sub_lender = 'ACME Sub-lender'
+      data_correction.should_not be_valid
+      data_correction.should have(1).error_on(:sub_lender)
+    end
+  end
 end

--- a/spec/presenters/loan_entry_spec.rb
+++ b/spec/presenters/loan_entry_spec.rb
@@ -362,6 +362,16 @@ describe LoanEntry do
       loan_entry.should have(1).error_on(:collateral_exhausted)
     end
 
+    context "when sub lenders exist for the lender" do
+      let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: loan_entry.lender) }
+
+      it "must have a sub-lender" do
+        loan_entry.sub_lender = nil
+        loan_entry.should_not be_valid
+        loan_entry.should have(1).error_on(:sub_lender)
+      end
+    end
+
     context 'phase 5' do
       let(:lender) { FactoryGirl.create(:lender) }
       let(:lending_limit) { FactoryGirl.create(:lending_limit, :phase_5, lender: lender) }

--- a/spec/presenters/loan_entry_spec.rb
+++ b/spec/presenters/loan_entry_spec.rb
@@ -370,6 +370,12 @@ describe LoanEntry do
         loan_entry.should_not be_valid
         loan_entry.should have(1).error_on(:sub_lender)
       end
+
+      it "must have an allowed sub-lender" do
+        loan_entry.sub_lender = "not a valid sub lender for this lender"
+        loan_entry.should_not be_valid
+        loan_entry.should have(1).error_on(:sub_lender)
+      end
     end
 
     context 'phase 5' do

--- a/spec/presenters/loan_entry_spec.rb
+++ b/spec/presenters/loan_entry_spec.rb
@@ -367,14 +367,14 @@ describe LoanEntry do
 
       it "must have a sub-lender" do
         loan_entry.sub_lender = nil
-        loan_entry.should_not be_valid
-        loan_entry.should have(1).error_on(:sub_lender)
+        expect(loan_entry).not_to be_valid
+        expect(loan_entry).to have(1).error_on(:sub_lender)
       end
 
       it "must have an allowed sub-lender" do
         loan_entry.sub_lender = "not a valid sub lender for this lender"
-        loan_entry.should_not be_valid
-        loan_entry.should have(1).error_on(:sub_lender)
+        expect(loan_entry).not_to be_valid
+        expect(loan_entry).to have(1).error_on(:sub_lender)
       end
     end
 

--- a/spec/presenters/loan_transfer/legacy_sflg_spec.rb
+++ b/spec/presenters/loan_transfer/legacy_sflg_spec.rb
@@ -4,7 +4,7 @@ describe LoanTransfer::LegacySflg do
   let(:lender) { FactoryGirl.create(:lender, :with_lending_limit) }
 
   let!(:loan) {
-    FactoryGirl.create(:loan, :offered, :guaranteed, :with_premium_schedule, :with_loan_securities, :legacy_sflg,
+    FactoryGirl.create(:loan, :offered, :guaranteed, :with_premium_schedule, :with_loan_securities, :legacy_sflg, :with_sub_lender,
       lender: lender,
       lender_reference: 'lenderref1'
     )
@@ -85,7 +85,7 @@ describe LoanTransfer::LegacySflg do
         generic5 transferred_from_id lending_limit_id created_at updated_at
         facility_letter_date declaration_signed state_aid state_aid_is_valid
         notified_aid viable_proposition collateral_exhausted previous_borrowing
-        would_you_lend legacy_id created_by_id lender_reference last_modified_at
+        would_you_lend legacy_id created_by_id lender_reference last_modified_at sub_lender
       )
 
       fields_to_compare = Loan.column_names - fields_not_copied

--- a/spec/presenters/loan_transfer/sflg_spec.rb
+++ b/spec/presenters/loan_transfer/sflg_spec.rb
@@ -4,7 +4,7 @@ describe LoanTransfer::Sflg do
   let(:lender) { FactoryGirl.create(:lender, :with_lending_limit) }
 
   let!(:loan) {
-    FactoryGirl.create(:loan, :offered, :guaranteed, :with_premium_schedule, :with_loan_securities, :sflg, lender: lender)
+    FactoryGirl.create(:loan, :offered, :guaranteed, :with_premium_schedule, :with_loan_securities, :sflg, :with_sub_lender, lender: lender)
   }
 
   let(:loan_transfer) {
@@ -44,7 +44,7 @@ describe LoanTransfer::Sflg do
         id lender_id reference state sortcode repayment_duration amount
         repayment_frequency_id maturity_date invoice_id generic1 generic2 generic3
         generic4 generic5 transferred_from_id lending_limit_id created_at
-        updated_at legacy_id created_by_id lender_reference last_modified_at
+        updated_at legacy_id created_by_id lender_reference last_modified_at sub_lender
       )
 
       fields_to_compare = Loan.column_names - fields_not_copied

--- a/spec/presenters/transferred_loan_entry_spec.rb
+++ b/spec/presenters/transferred_loan_entry_spec.rb
@@ -52,14 +52,14 @@ describe TransferredLoanEntry do
 
       it "must have a sub-lender" do
         transferred_loan_entry.sub_lender = nil
-        transferred_loan_entry.should_not be_valid
-        transferred_loan_entry.should have(1).error_on(:sub_lender)
+        expect(transferred_loan_entry).not_to be_valid
+        expect(transferred_loan_entry).to have(1).error_on(:sub_lender)
       end
 
       it "must have an allowed sub-lender" do
         transferred_loan_entry.sub_lender = "not a valid sub lender for this lender"
-        transferred_loan_entry.should_not be_valid
-        transferred_loan_entry.should have(1).error_on(:sub_lender)
+        expect(transferred_loan_entry).not_to be_valid
+        expect(transferred_loan_entry).to have(1).error_on(:sub_lender)
       end
     end
 

--- a/spec/presenters/transferred_loan_entry_spec.rb
+++ b/spec/presenters/transferred_loan_entry_spec.rb
@@ -47,6 +47,22 @@ describe TransferredLoanEntry do
       transferred_loan_entry.errors[:state_aid].should == ['must be calculated']
     end
 
+    context "when sub lenders exist for the lender" do
+      let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: transferred_loan_entry.lender) }
+
+      it "must have a sub-lender" do
+        transferred_loan_entry.sub_lender = nil
+        transferred_loan_entry.should_not be_valid
+        transferred_loan_entry.should have(1).error_on(:sub_lender)
+      end
+
+      it "must have an allowed sub-lender" do
+        transferred_loan_entry.sub_lender = "not a valid sub lender for this lender"
+        transferred_loan_entry.should_not be_valid
+        transferred_loan_entry.should have(1).error_on(:sub_lender)
+      end
+    end
+
     it_behaves_like 'loan presenter that validates loan repayment frequency' do
       let(:loan_presenter) { transferred_loan_entry }
     end

--- a/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
+++ b/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
@@ -18,23 +18,23 @@ describe 'Sub Lender Data Correction' do
 
     it do
       click_button 'Submit'
-      page.should have_content "old sub-lender"
-      page.should have_content "a sub-lender must be chosen"
+      expect(page).to have_content "old sub-lender"
+      expect(page).to have_content "a sub-lender must be chosen"
 
       select new_value, from: 'data_correction_sub_lender'
       click_button 'Submit'
 
       data_correction = loan.data_corrections.last!
-      data_correction.change_type.should == ChangeType::SubLender
-      data_correction.created_by.should == current_user
-      data_correction.date_of_change.should == Date.current
-      data_correction.modified_date.should == Date.current
-      data_correction.old_sub_lender.should == old_value
-      data_correction.sub_lender.should == new_value
+      expect(data_correction.change_type).to eql(ChangeType::SubLender)
+      expect(data_correction.created_by).to eql(current_user)
+      expect(data_correction.date_of_change).to eql(Date.current)
+      expect(data_correction.modified_date).to eql(Date.current)
+      expect(data_correction.old_sub_lender).to eql(old_value)
+      expect(data_correction.sub_lender).to eql(new_value)
 
       loan.reload
-      loan.sub_lender.should == new_value
-      loan.modified_by.should == current_user
+      expect(loan.sub_lender).to eql(new_value)
+      expect(loan.modified_by).to eql(current_user)
     end
   end
 
@@ -42,7 +42,7 @@ describe 'Sub Lender Data Correction' do
     context "and loan has no existing sub-lender value" do
       it "does not show link to Sub-lender data correction" do
         visit_data_corrections
-        page.should_not have_css('a', text: 'Sub-lender')
+        expect(page).to_not have_css('a', text: 'Sub-lender')
       end
     end
 
@@ -53,7 +53,7 @@ describe 'Sub Lender Data Correction' do
 
       it "shows link to Sub-lender data correction" do
         visit_data_corrections
-        page.should have_css('a', text: 'Sub-lender')
+        expect(page).to have_css('a', text: 'Sub-lender')
       end
     end
   end

--- a/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
+++ b/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'Sub Lender Data Correction' do
   include DataCorrectionSpecHelper
 
-  context "lender has sub-lenders" do
+  let!(:loan) { FactoryGirl.create(:loan, :guaranteed, lender: current_user.lender) }
 
-    let!(:loan) { FactoryGirl.create(:loan, :guaranteed, lender: current_user.lender) }
+  context "lender has sub-lenders" do
     let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: loan.lender) }
     let!(:old_value) { loan.sub_lender }
     let!(:new_value) { sub_lender.name }
@@ -30,6 +30,13 @@ describe 'Sub Lender Data Correction' do
       loan.reload
       loan.sub_lender.should == new_value
       loan.modified_by.should == current_user
+    end
+  end
+
+  context "lender has no sub-lenders and loan has no existing sub-lender" do
+    it "does not show link to Sub-lender data correction" do
+      visit_data_corrections
+      page.should_not have_css('a', text: 'Sub-lender')
     end
   end
 end

--- a/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
+++ b/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
@@ -38,10 +38,23 @@ describe 'Sub Lender Data Correction' do
     end
   end
 
-  context "lender has no sub-lenders and loan has no existing sub-lender" do
-    it "does not show link to Sub-lender data correction" do
-      visit_data_corrections
-      page.should_not have_css('a', text: 'Sub-lender')
+  context "lender has no sub-lenders" do
+    context "and loan has no existing sub-lender value" do
+      it "does not show link to Sub-lender data correction" do
+        visit_data_corrections
+        page.should_not have_css('a', text: 'Sub-lender')
+      end
+    end
+
+    context "and loan has sub-lender value" do
+      before do
+        loan.update_column(:sub_lender, 'ACME')
+      end
+
+      it "shows link to Sub-lender data correction" do
+        visit_data_corrections
+        page.should have_css('a', text: 'Sub-lender')
+      end
     end
   end
 end

--- a/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
+++ b/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
@@ -7,15 +7,20 @@ describe 'Sub Lender Data Correction' do
 
   context "lender has sub-lenders" do
     let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: loan.lender) }
-    let!(:old_value) { loan.sub_lender }
+    let!(:old_value) { "old sub-lender" }
     let!(:new_value) { sub_lender.name }
 
     before do
+      loan.update_column(:sub_lender, old_value)
       visit_data_corrections
       click_link "Sub-lender"
     end
 
     it do
+      click_button 'Submit'
+      page.should have_content "old sub-lender"
+      page.should have_content "a sub-lender must be chosen"
+
       select new_value, from: 'data_correction_sub_lender'
       click_button 'Submit'
 

--- a/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
+++ b/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'Sub Lender Data Correction' do
+  include DataCorrectionSpecHelper
+
+  context "lender has sub-lenders" do
+
+    let!(:loan) { FactoryGirl.create(:loan, :guaranteed, lender: current_user.lender) }
+    let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: loan.lender) }
+    let!(:old_value) { loan.sub_lender }
+    let!(:new_value) { sub_lender.name }
+
+    before do
+      visit_data_corrections
+      click_link "Sub-lender"
+    end
+
+    it do
+      select new_value, from: 'data_correction_sub_lender'
+      click_button 'Submit'
+
+      data_correction = loan.data_corrections.last!
+      data_correction.change_type.should == ChangeType::SubLender
+      data_correction.created_by.should == current_user
+      data_correction.date_of_change.should == Date.current
+      data_correction.modified_date.should == Date.current
+      data_correction.old_sub_lender.should == old_value
+      data_correction.sub_lender.should == new_value
+
+      loan.reload
+      loan.sub_lender.should == new_value
+      loan.modified_by.should == current_user
+    end
+  end
+end

--- a/spec/requests/loans/loan_entry_spec.rb
+++ b/spec/requests/loans/loan_entry_spec.rb
@@ -187,6 +187,27 @@ describe 'loan entry' do
     end
   end
 
+  context "when sub lenders exist for the lender" do
+    let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: lender, name: "ACME sublender")}
+
+    it "should require the selection of a sub-lender" do
+      visit new_loan_entry_path(loan)
+
+      fill_in_valid_loan_entry_details_phase_5(loan)
+
+      click_button 'Submit'
+
+      page.should have_content("a sub-lender must be chosen")
+      select "ACME sublender", from: "Sub-lender"
+
+      click_button "Submit"
+      current_path.should == complete_loan_entry_path(loan)
+
+      loan.reload
+      loan.sub_lender.should == "ACME sublender"
+    end
+  end
+
   context "with loan in sector with reduced state aid threshold" do
     let(:sic_code) { SicCode.find_by_code!(loan.sic_code) }
 

--- a/spec/requests/loans/loan_entry_spec.rb
+++ b/spec/requests/loans/loan_entry_spec.rb
@@ -197,14 +197,14 @@ describe 'loan entry' do
 
       click_button 'Submit'
 
-      page.should have_content("a sub-lender must be chosen")
+      expect(page).to have_content("a sub-lender must be chosen")
       select "ACME sublender", from: "Sub-lender"
 
       click_button "Submit"
-      current_path.should == complete_loan_entry_path(loan)
+      expect(current_path).to eql(complete_loan_entry_path(loan))
 
       loan.reload
-      loan.sub_lender.should == "ACME sublender"
+      expect(loan.sub_lender).to eql("ACME sublender")
     end
   end
 

--- a/spec/requests/loans/transferred_loan_entry_spec.rb
+++ b/spec/requests/loans/transferred_loan_entry_spec.rb
@@ -40,7 +40,7 @@ describe 'Transferred loan entry' do
     loan.lender_reference.should == 'lenderref1'
     loan.repayment_frequency_id.should == 3
     loan.repayment_duration.should == MonthDuration.new(18)
-    loan.sub_lender.should == "ACME sublender"
+    expect(loan.sub_lender).to eql("ACME sublender")
     loan.generic1.should == 'Generic 1'
     loan.generic2.should == 'Generic 2'
     loan.generic3.should == 'Generic 3'
@@ -57,9 +57,9 @@ describe 'Transferred loan entry' do
       click_button 'Submit'
     }.not_to change(loan, :state)
 
-    page.should have_content "must be accepted"
-    page.should have_content "must be calculated"
-    page.should have_content "a sub-lender must be chosen"
+    expect(page).to have_content "must be accepted"
+    expect(page).to have_content "must be calculated"
+    expect(page).to have_content "a sub-lender must be chosen"
   end
 
 end

--- a/spec/requests/loans/transferred_loan_entry_spec.rb
+++ b/spec/requests/loans/transferred_loan_entry_spec.rb
@@ -52,4 +52,14 @@ describe 'Transferred loan entry' do
     should_log_loan_state_change(loan, Loan::Completed, 4, current_user)
   end
 
+  it "does not continue with invalid values" do
+    expect {
+      click_button 'Submit'
+    }.not_to change(loan, :state)
+
+    page.should have_content "must be accepted"
+    page.should have_content "must be calculated"
+    page.should have_content "a sub-lender must be chosen"
+  end
+
 end

--- a/spec/requests/loans/transferred_loan_entry_spec.rb
+++ b/spec/requests/loans/transferred_loan_entry_spec.rb
@@ -5,6 +5,7 @@ describe 'Transferred loan entry' do
   let(:current_user) { FactoryGirl.create(:lender_user) }
 
   let(:loan) { FactoryGirl.create(:loan, :transferred, lender: current_user.lender) }
+  let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: loan.lender, name: "ACME sublender")}
 
   before(:each) do
     login_as(current_user, scope: :user)
@@ -18,6 +19,7 @@ describe 'Transferred loan entry' do
     fill_in 'transferred_loan_entry_lender_reference', with: 'lenderref1'
     fill_in "transferred_loan_entry_repayment_duration_years", with: 1
     fill_in "transferred_loan_entry_repayment_duration_months", with: 6
+    select "ACME sublender", from: "Sub-lender"
 
     calculate_state_aid(loan)
 
@@ -38,6 +40,7 @@ describe 'Transferred loan entry' do
     loan.lender_reference.should == 'lenderref1'
     loan.repayment_frequency_id.should == 3
     loan.repayment_duration.should == MonthDuration.new(18)
+    loan.sub_lender.should == "ACME sublender"
     loan.generic1.should == 'Generic 1'
     loan.generic2.should == 'Generic 2'
     loan.generic3.should == 'Generic 3'

--- a/spec/requests/sub_lenders_request_spec.rb
+++ b/spec/requests/sub_lenders_request_spec.rb
@@ -22,8 +22,8 @@ describe 'Sub-lenders' do
 
       click_button 'Create Sub-lender'
 
-      page.should have_content("can't be blank")
-      lender.sub_lenders.count.should be_zero
+      expect(page).to have_content("can't be blank")
+      expect(lender.sub_lenders.count).to be_zero
     end
 
     it 'adds sub-lender' do
@@ -31,16 +31,16 @@ describe 'Sub-lenders' do
 
       click_button 'Create Sub-lender'
 
-      current_path.should == lender_sub_lenders_path(lender)
+      expect(current_path).to eql(lender_sub_lenders_path(lender))
 
       sub_lender = lender.sub_lenders.last
-      sub_lender.name.should == 'EMCA'
+      expect(sub_lender.name).to eql('EMCA')
 
       admin_audit = AdminAudit.last!
-      admin_audit.action.should == AdminAudit::SubLenderCreated
-      admin_audit.auditable.should == sub_lender
-      admin_audit.modified_by.should == current_user
-      admin_audit.modified_on.should == Date.current
+      expect(admin_audit.action).to eql(AdminAudit::SubLenderCreated)
+      expect(admin_audit.auditable).to eql(sub_lender)
+      expect(admin_audit.modified_by).to eql(current_user)
+      expect(admin_audit.modified_on).to eql(Date.current)
     end
   end
 
@@ -57,8 +57,8 @@ describe 'Sub-lenders' do
 
       click_button 'Update Sub-lender'
 
-      page.should have_content("can't be blank")
-      lender.sub_lenders.first.name.should == 'EMCA'
+      expect(page).to have_content("can't be blank")
+      expect(lender.sub_lenders.first.name).to eql('EMCA')
     end
 
     it 'changes the sub-lender' do
@@ -66,16 +66,16 @@ describe 'Sub-lenders' do
 
       click_button 'Update Sub-lender'
 
-      current_path.should == lender_sub_lenders_path(lender)
+      expect(current_path).to eql(lender_sub_lenders_path(lender))
 
       sub_lender.reload
-      sub_lender.name.should == 'Foo'
+      expect(sub_lender.name).to eql('Foo')
 
       admin_audit = AdminAudit.last!
-      admin_audit.action.should == AdminAudit::SubLenderEdited
-      admin_audit.auditable.should == sub_lender
-      admin_audit.modified_by.should == current_user
-      admin_audit.modified_on.should == Date.current
+      expect(admin_audit.action).to eql(AdminAudit::SubLenderEdited)
+      expect(admin_audit.auditable).to eql(sub_lender)
+      expect(admin_audit.modified_by).to eql(current_user)
+      expect(admin_audit.modified_on).to eql(Date.current)
     end
   end
 
@@ -88,7 +88,7 @@ describe 'Sub-lenders' do
 
     it do
       click_link 'Delete'
-      page.should_not have_content sub_lender.name
+      expect(page).to_not have_content sub_lender.name
     end
   end
 

--- a/spec/requests/sub_lenders_request_spec.rb
+++ b/spec/requests/sub_lenders_request_spec.rb
@@ -22,7 +22,7 @@ describe 'Sub-lenders' do
 
       click_button 'Create Sub-lender'
 
-      current_path.should == lender_lender_sub_lenders_path(lender)
+      current_path.should == lender_sub_lender_path(lender)
     end
 
     it 'adds sub-lender' do
@@ -32,8 +32,14 @@ describe 'Sub-lenders' do
 
       current_path.should == lender_sub_lenders_path(lender)
 
-      lender.reload
-      lender.sub_lenders.collect(&:name).should include('EMCA')
+      sub_lender = lender.sub_lenders.last
+      sub_lender.name.should == 'EMCA'
+
+      admin_audit = AdminAudit.last!
+      admin_audit.action.should == AdminAudit::SubLenderCreated
+      admin_audit.auditable.should == sub_lender
+      admin_audit.modified_by.should == current_user
+      admin_audit.modified_on.should == Date.current
     end
   end
 
@@ -60,7 +66,13 @@ describe 'Sub-lenders' do
       current_path.should == lender_sub_lenders_path(lender)
 
       sub_lender.reload
-      sub_lender.name.should eql('Foo')
+      sub_lender.name.should == 'Foo'
+
+      admin_audit = AdminAudit.last!
+      admin_audit.action.should == AdminAudit::SubLenderEdited
+      admin_audit.auditable.should == sub_lender
+      admin_audit.modified_by.should == current_user
+      admin_audit.modified_on.should == Date.current
     end
   end
 

--- a/spec/requests/sub_lenders_request_spec.rb
+++ b/spec/requests/sub_lenders_request_spec.rb
@@ -79,6 +79,19 @@ describe 'Sub-lenders' do
     end
   end
 
+  describe 'delete sub-lender' do
+    let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: lender) }
+
+    before do
+      click_link 'Sub-lenders'
+    end
+
+    it do
+      click_link 'Delete'
+      page.should_not have_content sub_lender.name
+    end
+  end
+
   private
 
   def fill_in(attribute, value)

--- a/spec/requests/sub_lenders_request_spec.rb
+++ b/spec/requests/sub_lenders_request_spec.rb
@@ -22,7 +22,8 @@ describe 'Sub-lenders' do
 
       click_button 'Create Sub-lender'
 
-      current_path.should == lender_sub_lender_path(lender)
+      page.should have_content("can't be blank")
+      lender.sub_lenders.count.should be_zero
     end
 
     it 'adds sub-lender' do

--- a/spec/requests/sub_lenders_request_spec.rb
+++ b/spec/requests/sub_lenders_request_spec.rb
@@ -9,11 +9,11 @@ describe 'Sub-lenders' do
   before do
     visit root_path
     click_link 'Manage Lenders'
-    click_link 'Sub-lenders'
   end
 
   describe 'creating new sub-lenders' do
     before do
+      click_link 'Sub-lenders'
       click_link 'New Sub-lender'
     end
 
@@ -48,6 +48,7 @@ describe 'Sub-lenders' do
     let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: lender, name: 'EMCA') }
 
     before do
+      click_link 'Sub-lenders'
       click_link 'EMCA'
     end
 
@@ -56,7 +57,8 @@ describe 'Sub-lenders' do
 
       click_button 'Update Sub-lender'
 
-      current_path.should == lender_sub_lender_path(sub_lender)
+      page.should have_content("can't be blank")
+      lender.sub_lenders.first.name.should == 'EMCA'
     end
 
     it 'changes the sub-lender' do

--- a/spec/requests/sub_lenders_request_spec.rb
+++ b/spec/requests/sub_lenders_request_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe 'Sub-lenders' do
+  let(:current_user) { FactoryGirl.create(:cfe_admin) }
+  let!(:lender) { FactoryGirl.create(:lender, name: 'ACME') }
+
+  before { login_as(current_user, scope: :user) }
+
+  before do
+    visit root_path
+    click_link 'Manage Lenders'
+    click_link 'Sub-lenders'
+  end
+
+  describe 'creating new sub-lenders' do
+    before do
+      click_link 'New Sub-lender'
+    end
+
+    it 'does not continue with invalid values' do
+      fill_in 'name', ''
+
+      click_button 'Create Sub-lender'
+
+      current_path.should == lender_lender_sub_lenders_path(lender)
+    end
+
+    it 'adds sub-lender' do
+      fill_in 'name', 'EMCA'
+
+      click_button 'Create Sub-lender'
+
+      current_path.should == lender_sub_lenders_path(lender)
+
+      lender.reload
+      lender.sub_lenders.collect(&:name).should include('EMCA')
+    end
+  end
+
+  describe 'updating existing sub-lenders' do
+    let!(:sub_lender) { FactoryGirl.create(:sub_lender, lender: lender, name: 'EMCA') }
+
+    before do
+      click_link 'EMCA'
+    end
+
+    it 'does not continue with invalid values' do
+      fill_in 'name', ''
+
+      click_button 'Update Sub-lender'
+
+      current_path.should == lender_sub_lender_path(sub_lender)
+    end
+
+    it 'changes the sub-lender' do
+      fill_in 'name', 'Foo'
+
+      click_button 'Update Sub-lender'
+
+      current_path.should == lender_sub_lenders_path(lender)
+
+      sub_lender.reload
+      sub_lender.name.should eql('Foo')
+    end
+  end
+
+  private
+
+  def fill_in(attribute, value)
+    page.fill_in "sub_lender_#{attribute}", with: value
+  end
+
+end

--- a/spec/support/shared_examples/data_correction_shared_examples.rb
+++ b/spec/support/shared_examples/data_correction_shared_examples.rb
@@ -60,6 +60,17 @@ shared_examples_for 'a basic data correction presenter' do |attribute, input_val
     end
   end
 
+  it_behaves_like "loan updating data correction presenter", attribute, input_value, new_value, loan_attrs
+
+end
+
+shared_examples_for "loan updating data correction presenter" do |attribute, input_value, new_value = nil, loan_attrs = {}|
+  let(:factory_name) { "#{attribute}_data_correction" }
+  let(:user) { FactoryGirl.create(:lender_user) }
+  let(:loan) { FactoryGirl.create(:loan, :guaranteed, loan_attrs) }
+  let(:presenter) { FactoryGirl.build(factory_name, created_by: user, loan: loan) }
+  let(:expected_new_value) { new_value || input_value }
+
   describe '#save' do
     let!(:old_value) { loan.public_send(attribute) }
 

--- a/spec/support/shared_examples/loan_transfer_shared_examples.rb
+++ b/spec/support/shared_examples/loan_transfer_shared_examples.rb
@@ -85,7 +85,7 @@ shared_examples_for 'a loan transfer' do
       end
 
       it 'should create new loan with no value for sub-lender' do
-        new_loan.sub_lender.should be_blank
+        expect(new_loan.sub_lender).to be_blank
       end
 
       it 'should create new loan with no value for generic fields' do

--- a/spec/support/shared_examples/loan_transfer_shared_examples.rb
+++ b/spec/support/shared_examples/loan_transfer_shared_examples.rb
@@ -84,6 +84,10 @@ shared_examples_for 'a loan transfer' do
         new_loan.maturity_date.should be_blank
       end
 
+      it 'should create new loan with no value for sub-lender' do
+        new_loan.sub_lender.should be_blank
+      end
+
       it 'should create new loan with no value for generic fields' do
         (1..5).each do |num|
           new_loan.send("generic#{num}").should be_blank

--- a/spec/views/loan_details_spec.rb
+++ b/spec/views/loan_details_spec.rb
@@ -207,4 +207,12 @@ describe 'loans/details' do
       let(:visible_details) { %w(loan_entry.business_name) }
     end
   end
+
+  context "with a loan with sub-lender" do
+    let(:loan) { FactoryGirl.build(:loan, :with_sub_lender) }
+
+    it_behaves_like 'rendered loan_details' do
+      let(:visible_details) { %w(loan_entry.sub_lender) }
+    end
+  end
 end


### PR DESCRIPTION
Loans for certain lenders belong to a specific 'sub-lender'. Currently the sub-lender is recorded in one of the generic fields but we want this data to be managed and displayed more consistently.

* CfeAdmins manage the available sub-lender options for each lender. 

* Lenders with sub-lender options *must* now choose a sub-lender at Loan Entry.

* A data correction form allows modifying the sub-lender on existing loans.

The sub-lender value is stored as a string on the loan so that if the available sub-lender options are changed in the future, the sub-lender value for existing loans is not mistakenly changed also. 

We are not migrating existing sub-lender data (i.e. from the generic fields) with this change. BBB or the lenders themselves can do this in due course with a data correction.
