### PR TITLE
Handle strings with ‘ in them

### DIFF
--- a/db/migrate/20150116154426_move_data_corrections_out_of_loan_modifications.rb
+++ b/db/migrate/20150116154426_move_data_corrections_out_of_loan_modifications.rb
@@ -50,12 +50,12 @@ class MoveDataCorrectionsOutOfLoanModifications < ActiveRecord::Migration
       populated_columns = mod.select { |key, value| value.present? }
 
       populated_columns = populated_columns.each_with_object({}) do |(key, value), memo|
-        memo[key] = value.is_a?(Date) || value.is_a?(Time) ? value.to_s(:db) : value.to_s
+        memo[key] = value.is_a?(Date) || value.is_a?(Time) ? value.to_s(:db) : ActiveRecord::Base.connection.quote(value.to_s)
       end
 
       execute("
         INSERT INTO data_corrections (#{populated_columns.keys.join(',')})
-        VALUES ('#{populated_columns.values.join("','")}')
+        VALUES ('#{populated_columns.values.join(",")}')
       ")
     end
   end
@@ -72,12 +72,12 @@ class MoveDataCorrectionsOutOfLoanModifications < ActiveRecord::Migration
       populated_columns = populated_columns.each_with_object({}) do |(key, value), memo|
         # ensure load_id and seq are unique to satisfy index
         value = max_sequence + 1 if key == 'seq'
-        memo[key] = value.is_a?(Date) || value.is_a?(Time) ? value.to_s(:db) : value.to_s
+        memo[key] = value.is_a?(Date) || value.is_a?(Time) ? value.to_s(:db) : ActiveRecord::Base.connection.quote(value.to_s)
       end
 
       execute("
         INSERT INTO loan_modifications (type, #{populated_columns.keys.join(',')})
-        VALUES ('DataCorrection','#{populated_columns.values.join("','")}')
+        VALUES ('DataCorrection','#{populated_columns.values.join(",")}')
       ")
     end
   end

--- a/spec/requests/data_corrections/string_escaping_spec.rb
+++ b/spec/requests/data_corrections/string_escaping_spec.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe 'eligibility checks' do
+
+  it 'escapes strings' do
+    ActiveRecord::Base.connection.quote("Ben and Niall's shop").should eq("'Ben and Niall\\'s shop'")
+  end
+
+  it 'escapes numbers' do
+    ActiveRecord::Base.connection.quote(0).should eq('0')
+  end
+
+end


### PR DESCRIPTION
This migration failed in one environment with

[efg-frontend-1] executing command
*** [err :: efg-frontend-1] rake aborted!
*** [err :: efg-frontend-1] StandardError: An error has occurred, all later migrations canceled:
*** [err :: efg-frontend-1] 
*** [err :: efg-frontend-1] Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'S LTD')' at line 2:
*** [err :: efg-frontend-1] INSERT INTO data_corrections (loan_id,created_by_id,change_type_id,oid,seq,date_of_change,modified_date,modified_user,ar_timestamp,ar_insert_timestamp,_legacy_business_name,_legacy_old_business_name)
*** [err :: efg-frontend-1] VALUES ('1','1','1','1','1','1970-01-01','1970-01-01','jabley','1970-01-01 00:00:00','1970-01-01 00:00:00','ACME LIMITED','Ben and Niall's LTD')