### PR TITLE
Guaranteed draw button

### DIFF
--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -185,6 +185,10 @@ class Loan < ActiveRecord::Base
     cumulative_recoveries_amount - cumulative_realised_amount
   end
 
+  def drawable?
+    amount > cumulative_drawn_amount
+  end
+
   def last_realisation_amount
     loan_realisations.present? ? loan_realisations.last.realised_amount : Money.new(0)
   end

--- a/app/views/loans/buttons/_guaranteed.html.erb
+++ b/app/views/loans/buttons/_guaranteed.html.erb
@@ -1,6 +1,6 @@
 <div class="form-actions">
   <%= link_to('Change Amount or Terms', loan_loan_changes_path(@loan), class: 'btn') if current_user.can_create?(LoanChange) %>
-  <%= link_to('Record Agreed Draw', new_loan_agreed_draw_path(@loan), class: 'btn') if current_user.can_create?(AgreedDraw) && @loan.has_drawdowns? %>
+  <%= link_to('Record Agreed Draw', new_loan_agreed_draw_path(@loan), class: 'btn') if current_user.can_create?(AgreedDraw) && @loan.drawable? %>
   <%= link_to('Demand to Borrower', new_loan_demand_to_borrower_path(@loan), class: 'btn') if current_user.can_create?(LoanDemandToBorrower) %>
   <%= link_to('Remove Guarantee', new_loan_remove_guarantee_path(@loan), class: 'btn') if current_user.can_create?(LoanRemoveGuarantee) %>
   <%= link_to('Repay Loan', new_loan_repay_path(@loan), class: 'btn') if current_user.can_create?(LoanRepay) %>

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -233,6 +233,17 @@ describe Loan do
     end
   end
 
+  describe '#drawable?' do
+    it 'returns true when the cumulative drawn amount equals the loan amount' do
+      FactoryGirl.create(:initial_draw_change, loan: loan, amount_drawn: Money.new(10_000_00))
+      expect(loan).to be_drawable
+      FactoryGirl.create(:loan_change, loan: loan, amount_drawn: Money.new(2_000_00), change_type: ChangeType::RecordAgreedDraw)
+      expect(loan).to be_drawable
+      FactoryGirl.create(:loan_change, loan: loan, amount_drawn: Money.new(345_00), change_type: ChangeType::RecordAgreedDraw)
+      expect(loan).not_to be_drawable
+    end
+  end
+
   describe '#cumulative_pre_claim_limit_realised_amount' do
     context 'with loan_realisations' do
       before do
@@ -436,7 +447,7 @@ describe Loan do
       it "returns the loan's category specific guarantee rate" do
         loan.guarantee_rate.should == 75
       end
-    end  
+    end
   end
 
   describe "#premium_rate" do

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -52,7 +52,7 @@ describe Search do
       let!(:user) { FactoryGirl.create(:lender_user, lender: lending_limit1.lender) }
 
       it "should return all of the user's lender's lending limits" do
-        search.lending_limits.should == [ lending_limit1 ]
+        search.lending_limits.should match_array [ lending_limit1 ]
       end
     end
 
@@ -60,7 +60,7 @@ describe Search do
       let(:user) { FactoryGirl.build(:auditor_user) }
 
       it "should return all lending limits when " do
-        search.lending_limits.should == [ lending_limit1, lending_limit2 ]
+        search.lending_limits.should match_array [ lending_limit1, lending_limit2 ]
       end
     end
   end

--- a/spec/requests/agreed_draw_request_spec.rb
+++ b/spec/requests/agreed_draw_request_spec.rb
@@ -6,20 +6,23 @@ describe 'agreed draw' do
 
   let(:loan) { FactoryGirl.create(:loan, :guaranteed, amount: Money.new(100_000_00), maturity_date: Date.new(2014, 12, 25), repayment_duration: 60) }
 
-  context 'for a loan with no drawdowns' do
+  context 'where loan is fully drawn' do
     before do
-      FactoryGirl.create(:premium_schedule, loan: loan)
+      FactoryGirl.create(:premium_schedule, :with_drawdowns, loan: loan)
+      FactoryGirl.create(:loan_change, loan: loan, amount_drawn: Money.new(90_000_00), change_type: ChangeType::RecordAgreedDraw)
+      expect(loan.amount_not_yet_drawn).to eq(0)
+      visit loan_path(loan)
     end
 
     it 'does not include the reprofile draws option' do
       visit loan_path(loan)
-      page.should_not have_content('Record Agreed Draw')
+      page.should_not have_link('Record Agreed Draw')
     end
   end
 
-  context 'for a loan with drawdowns' do
+  context 'where loan is NOT fully drawn' do
     before do
-      FactoryGirl.create(:premium_schedule, :with_drawdowns, loan: loan)
+      expect(loan.amount_not_yet_drawn).to be > 0
       visit loan_path(loan)
       click_link 'Record Agreed Draw'
     end


### PR DESCRIPTION
Record Agreed Draw button always shows when the loan is not fully drawn (i.e. when loan has the capacity for further draws) - unless user doesn't have access.