### PR TITLE
Use rails_helper in all specs

### DIFF
--- a/spec/controllers/realisation_adjustments_controller_spec.rb
+++ b/spec/controllers/realisation_adjustments_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe RealisationAdjustmentsController do
   describe "GET new" do

--- a/spec/controllers/realisations_reports_controller_spec.rb
+++ b/spec/controllers/realisations_reports_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe RealisationsReportsController do
 

--- a/spec/controllers/recoveries_reports_controller_spec.rb
+++ b/spec/controllers/recoveries_reports_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe RecoveriesReportsController do
 

--- a/spec/controllers/sub_lenders_controller_spec.rb
+++ b/spec/controllers/sub_lenders_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe SubLendersController do
   let(:lender) { FactoryGirl.create(:lender) }

--- a/spec/exports/realisations_report_csv_export_spec.rb
+++ b/spec/exports/realisations_report_csv_export_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'csv'
 
 describe RealisationsReportCsvExport do

--- a/spec/exports/recoveries_report_csv_export_spec.rb
+++ b/spec/exports/recoveries_report_csv_export_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'csv'
 
 describe RecoveriesReportCsvExport do

--- a/spec/formatters/serialized_date_formatter_spec.rb
+++ b/spec/formatters/serialized_date_formatter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe SerializedDateFormatter do
   describe '::format' do

--- a/spec/models/realisation_adjustment_spec.rb
+++ b/spec/models/realisation_adjustment_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe RealisationAdjustment do
   describe 'validations' do

--- a/spec/models/sub_lender_spec.rb
+++ b/spec/models/sub_lender_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe SubLender do
 

--- a/spec/presenters/data_corrections/company_registration_data_correction_spec.rb
+++ b/spec/presenters/data_corrections/company_registration_data_correction_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe CompanyRegistrationDataCorrection do
   it_behaves_like 'a basic data correction presenter', :company_registration, '654321', nil, { legal_form_id: LegalForm::PLC.id }

--- a/spec/presenters/data_corrections/generic_fields_data_correction_spec.rb
+++ b/spec/presenters/data_corrections/generic_fields_data_correction_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe GenericFieldsDataCorrection do
 

--- a/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
+++ b/spec/presenters/data_corrections/sub_lender_data_correction_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe SubLenderDataCorrection do
   let(:current_user) { FactoryGirl.create(:lender_user) }

--- a/spec/presenters/data_corrections/trading_date_data_correction_spec.rb
+++ b/spec/presenters/data_corrections/trading_date_data_correction_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe TradingDateDataCorrection do
   it_behaves_like 'a basic data correction presenter', :trading_date, '01/10/14', Date.new(2014,10,1)

--- a/spec/presenters/data_corrections/trading_name_data_correction_spec.rb
+++ b/spec/presenters/data_corrections/trading_name_data_correction_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe TradingNameDataCorrection do
   it_behaves_like 'a basic data correction presenter', :trading_name, 'Bar'

--- a/spec/presenters/loan_amendment_presenter_spec.rb
+++ b/spec/presenters/loan_amendment_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe LoanAmendmentPresenter do
 

--- a/spec/presenters/loan_realisation_adjustment_spec.rb
+++ b/spec/presenters/loan_realisation_adjustment_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe LoanRealisationAdjustment do
   describe 'validations:' do

--- a/spec/reports/realisations_report_spec.rb
+++ b/spec/reports/realisations_report_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe RealisationsReport do
   describe 'validations' do

--- a/spec/requests/data_corrections/company_registration_data_correction_spec.rb
+++ b/spec/requests/data_corrections/company_registration_data_correction_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'Company Registration Data Correction' do
   it_behaves_like 'a basic data correction', :company_registration, '123456'

--- a/spec/requests/data_corrections/generic_fields_data_correction_request_spec.rb
+++ b/spec/requests/data_corrections/generic_fields_data_correction_request_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'Generic Fields Data Correction' do
 

--- a/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
+++ b/spec/requests/data_corrections/sub_lender_data_correction_request_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'Sub Lender Data Correction' do
   include DataCorrectionSpecHelper

--- a/spec/requests/data_corrections/trading_date_data_correction_spec.rb
+++ b/spec/requests/data_corrections/trading_date_data_correction_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'Trading Date Data Correction' do
   it_behaves_like 'a basic data correction', :trading_date, '01/10/14', Date.new(2014,10,1)

--- a/spec/requests/data_corrections/trading_name_data_correction_spec.rb
+++ b/spec/requests/data_corrections/trading_name_data_correction_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'Trading Name Data Correction' do
   it_behaves_like 'a basic data correction', :trading_name, 'Bar'

--- a/spec/requests/realisations_adjustment_request_spec.rb
+++ b/spec/requests/realisations_adjustment_request_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'making a realisation adjustment' do
   let(:current_user) { FactoryGirl.create(:cfe_user) }

--- a/spec/requests/sub_lenders_request_spec.rb
+++ b/spec/requests/sub_lenders_request_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'Sub-lenders' do
   let(:current_user) { FactoryGirl.create(:cfe_admin) }


### PR DESCRIPTION
Possibly missed during The Great Rebasing of 2016.

Only an issue when running individual spec files, hence why CI didn't catch it.