### PR TITLE
Fix loan entry failures

### DIFF
--- a/app/presenters/loan_entry.rb
+++ b/app/presenters/loan_entry.rb
@@ -64,7 +64,7 @@ class LoanEntry
   validates_presence_of :state_aid
   validates_presence_of :company_registration, if: ->(loan_entry) { loan_entry.legal_form_id.present? && LegalForm.company_registration_required?(loan_entry.legal_form_id) }
   validate :postcode_allowed
-  validate :state_aid_calculated
+  validate :state_aid_calculated, if: :recalculate_state_aid?
   validate :state_aid_within_sic_threshold, if: :state_aid
   validate :repayment_frequency_allowed
   validate :company_turnover_is_allowed, if: :turnover
@@ -108,9 +108,12 @@ class LoanEntry
     errors.add(:postcode, :invalid) unless postcode.full?
   end
 
-  # Note: state aid must be recalculated if the loan term has changed
+  def recalculate_state_aid?
+    loan.repayment_duration_changed?
+  end
+
   def state_aid_calculated
-    errors.add(:state_aid, :recalculate) if self.loan.repayment_duration_changed?
+    errors.add(:state_aid, :recalculate)
   end
 
   def validate_eligibility

--- a/spec/presenters/loan_entry_spec.rb
+++ b/spec/presenters/loan_entry_spec.rb
@@ -6,7 +6,7 @@ describe LoanEntry do
 
   before(:each) do
     # ensure recalculate state aid validation does not fail
-    allow_any_instance_of(Loan).to receive(:repayment_duration_changed?).and_return(false)
+    allow(loan_entry).to receive(:recalculate_state_aid?).and_return(false)
   end
 
   describe "validations" do
@@ -327,7 +327,7 @@ describe LoanEntry do
     context "when repayment duration is changed" do
       before(:each) do
         # ensure recalculate state aid validation fails
-        allow_any_instance_of(Loan).to receive(:repayment_duration_changed?).and_return(true)
+        allow(loan_entry).to receive(:recalculate_state_aid?).and_return(true)
       end
 
       it "should require a recalculation of state aid" do


### PR DESCRIPTION
Rspec’s verify_partial_doubles doesn’t seem to like ActiveRecord::Dirty’s {attr}_changed? methods.