### PR TITLE
Show popover with refinanced loan reason

### DIFF
--- a/app/assets/javascripts/select_popover.js
+++ b/app/assets/javascripts/select_popover.js
@@ -1,0 +1,25 @@
+(function($) {
+  $.fn.selectPopover = function() {
+    return this.each(function(_, element) {
+      var select = $(element)
+      var selectedOption;
+
+      select.change(function() {
+        selectedOption = $(this).find(":selected")
+
+        if (selectedOption.data("toggle") == "popover") {
+          select.popover({ 
+            content: selectedOption.data("content"),
+            placement: "bottom"
+          }).popover("show")
+        } else {
+          select.popover("destroy")
+        }
+      })
+    })
+  }
+})(jQuery)
+
+$(document).ready(function() {
+  $("[data-select-popover]").selectPopover()
+})

--- a/app/helpers/loan_helper.rb
+++ b/app/helpers/loan_helper.rb
@@ -66,4 +66,14 @@ module LoanHelper
     [Loan::Rejected, Loan::Incomplete].include?(loan.state) && loan.ineligibility_reasons.present?
   end
 
+  def loan_reason_options(reasons)
+    reasons.map do |r| 
+      array = [r.name, r.id] 
+      if r.notice_text.present?
+        array << { data: { content: r.notice_text, toggle: "popover" } }
+      end
+      array
+    end
+  end
+
 end

--- a/app/models/loan_reason.rb
+++ b/app/models/loan_reason.rb
@@ -227,6 +227,8 @@ class LoanReason < StaticAssociation
       name: 'Replacing existing finance',
       active: true,
       eligible: false,
+      notice_text: "This reason is not eligible. Please choose the original
+                    purpose of the funding being refinanced.",
     },
     {
       id: 38,

--- a/app/views/eligibility_checks/new.html.erb
+++ b/app/views/eligibility_checks/new.html.erb
@@ -20,7 +20,16 @@
     <%= f.input :trading_date, as: :quick_date %>
     <%= f.input :sic_code, as: :sic_code, collection: SicCode.active, input_html: { class: 'input-xxlarge' } %>
     <%= f.input :loan_category_id, as: :select, collection: LoanCategory.all, prompt: 'Please select', input_html: { class: 'input-xxlarge' } %>
-    <%= f.input :reason_id, as: :select, collection: LoanReason.active, prompt: 'Please select', input_html: { class: 'input-xxlarge' } %>
+
+    <%= f.input :reason_id do %>
+      <%= f.select(
+        :reason_id,
+        loan_reason_options(LoanReason.active),
+        { prompt: true },
+        { class: "input-xxlarge", data: { "select-popover" => true } }
+      ) %>
+    <% end %>
+
     <%= f.input :previous_borrowing, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
     <%= f.input :private_residence_charge_required, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>
     <%= f.input :personal_guarantee_required, as: :radio_buttons, wrapper_html: {class: 'radio-buttons-inline'} %>

--- a/app/views/loan_entries/new.html.erb
+++ b/app/views/loan_entries/new.html.erb
@@ -34,7 +34,16 @@
     <%= f.input :repayment_frequency_id, as: :select, collection: RepaymentFrequency.selectable, prompt: 'Please select', input_html: { class: 'input-xxlarge' } %>
     <%= simple_form_row t('simple_form.labels.loan_entry.sic_code'), @loan.sic_code %>
     <%= simple_form_row t('simple_form.labels.loan_entry.sic_desc'), @loan.sic_desc %>
-    <%= f.input :reason_id, as: :select, collection: LoanReason.active, prompt: 'Please select', input_html: { class: 'input-xxlarge' } %>
+    
+    <%= f.input :reason_id do %>
+      <%= f.select(
+        :reason_id,
+        loan_reason_options(LoanReason.active),
+        { prompt: true },
+        { class: "input-xxlarge", data: { "select-popover" => true } }
+      ) %>
+    <% end %>
+
     <%= f.input :interest_rate_type_id, as: :radio_buttons, collection: InterestRateType.all, wrapper_html: {class: 'radio-buttons-inline'} %>
     <%= f.input :interest_rate, as: :string %>
     <%= f.input :fees, as: :currency %>

--- a/spec/requests/loans/eligibility_checks_spec.rb
+++ b/spec/requests/loans/eligibility_checks_spec.rb
@@ -125,4 +125,11 @@ describe 'eligibility checks' do
     expect(current_path).to eq(loan_path(loan))
     expect(page).to have_content("Your email was sent successfully")
   end
+
+  it "has popover text to display when choosing refinanced loan reason" do
+    visit root_path
+    click_link "New Loan Application"
+
+    expect(page).to have_css("option[value='37'][data-toggle='popover']")
+  end
 end

--- a/spec/requests/loans/loan_entry_spec.rb
+++ b/spec/requests/loans/loan_entry_spec.rb
@@ -222,6 +222,11 @@ describe 'loan entry' do
     end
   end
 
+  it "has popover text to display when choosing refinanced loan reason" do
+    visit new_loan_entry_path(loan)
+    expect(page).to have_css("option[value='37'][data-toggle='popover']")
+  end
+
   private
 
     def should_show_only_loan_category_fields(*field_names)


### PR DESCRIPTION
Refinanced loans are ineligible. The popover prompts the user to choose
another option to avoid the loan being ineligible when submitted.