### PR TITLE
Update Recovery validations for older records

### DIFF
--- a/app/models/recovery.rb
+++ b/app/models/recovery.rb
@@ -118,11 +118,24 @@ class Recovery < ActiveRecord::Base
     end
 
     def validate_scheme_fields
-      required = if loan.efg_loan?
-        [:linked_security_proceeds, :outstanding_prior_non_efg_debt,
-         :outstanding_subsequent_non_efg_debt, :non_linked_security_proceeds]
+      if loan.efg_loan?
+        required = [
+          :linked_security_proceeds,
+          :outstanding_prior_non_efg_debt,
+          :non_linked_security_proceeds,
+        ]
+
+        # only newer recoveries require this field
+        # older, existing recoveries will have no value for this field
+        # so should still be valid
+        if new_record?
+          required << :outstanding_subsequent_non_efg_debt
+        end
       else
-        [:total_liabilities_behind, :total_liabilities_after_demand]
+        required = [
+          :total_liabilities_behind,
+          :total_liabilities_after_demand,
+        ]
       end
 
       required.each do |attribute|

--- a/spec/models/recovery_spec.rb
+++ b/spec/models/recovery_spec.rb
@@ -51,6 +51,15 @@ describe Recovery do
           expect(recovery).not_to be_valid
         end
       end
+
+      it "outstanding_subsequent_non_efg_debt is not required existing
+          EFG recoveries" do
+        recovery.outstanding_subsequent_non_efg_debt = nil
+        recovery.valid?
+        recovery.save(validate: false)
+
+        expect(recovery.reload).to be_valid
+      end
     end
 
     [:sflg, :legacy_sflg].each do |scheme|

--- a/spec/requests/realise_loans_spec.rb
+++ b/spec/requests/realise_loans_spec.rb
@@ -34,7 +34,12 @@ describe 'Realise loans' do
     recovery2 = FactoryGirl.create(:recovery, loan: loan2, recovered_on: Date.new(2011, 2, 20))
     recovery3 = FactoryGirl.create(:recovery, loan: loan3, recovered_on: Date.new(2012, 5, 5))
     recovery5 = FactoryGirl.create(:recovery, loan: loan5, recovered_on: Date.new(2012, 5, 5))
-    recovery6 = FactoryGirl.create(:recovery, loan: loan6, recovered_on: Date.new(2011, 2, 20))
+
+    # older EFG recovery before
+    # outstanding_subsequent_non_efg_debt was introduced
+    recovery6 = FactoryGirl.build(:recovery, loan: loan6, recovered_on: Date.new(2011, 2, 20), outstanding_subsequent_non_efg_debt: nil, seq: 0)
+    recovery6.valid?
+    recovery6.save(validate: false)
 
     select_loans
 


### PR DESCRIPTION
Older recoveries will not have a value for `outstanding_subsequent_non_efg_debt` so should still be valid when updated (typically via a realisation).

All new recovery records must have `outstanding_subsequent_non_efg_debt`.