### PR TITLE
Don’t carry forward capital repayment holidays

### DIFF
--- a/app/presenters/loan_change_presenter.rb
+++ b/app/presenters/loan_change_presenter.rb
@@ -54,6 +54,7 @@ class LoanChangePresenter
     @premium_schedule ||= new_premium_schedule.tap do |premium_schedule|
       premium_schedule.calc_type = PremiumSchedule::RESCHEDULE_TYPE
       premium_schedule.initial_draw_amount = nil
+      premium_schedule.initial_capital_repayment_holiday = 0
       premium_schedule.seq = nil
     end
   end

--- a/spec/requests/loan_changes/reprofile_draws_loan_change_request_spec.rb
+++ b/spec/requests/loan_changes/reprofile_draws_loan_change_request_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe 'Reprofile draws loan change' do
   include LoanChangeSpecHelper
 
-  it_behaves_like "loan change on loan with capital repayment holiday"
   it_behaves_like "loan change on loan with no premium schedule"
 
   before do

--- a/spec/support/shared_examples/loan_change_request_specs_shared_examples.rb
+++ b/spec/support/shared_examples/loan_change_request_specs_shared_examples.rb
@@ -38,12 +38,12 @@ shared_examples_for "loan change on loan with capital repayment holiday" do
       premium_schedule.save!
     end
 
-    it "retains capital repayment holiday duration in new premium schedule" do
+    it "removes capital repayment holiday duration in new premium schedule" do
       dispatch
 
       loan.reload
       premium_schedule = loan.premium_schedules.last!
-      premium_schedule.initial_capital_repayment_holiday = 6
+      expect(premium_schedule.initial_capital_repayment_holiday).to eq(0)
     end
   end
 end


### PR DESCRIPTION
All loan changes were carrying forward the capital repayment holiday when duplicating the existing Premium Schedule. This was resulting in incorrect schedules as the CRH was not expected to be present. 

This explicitly sets CRH to 0 for all loan changes except CRH and Reprofile Loan Draws changes.