### PR TITLE
Fix low priority alert group styling

### DIFF
--- a/app/assets/stylesheets/loan_alerts.scss
+++ b/app/assets/stylesheets/loan_alerts.scss
@@ -99,7 +99,7 @@
 }
 
 .bar-chart {
-  margin: 0 20px;
+  margin: 0 12px;
   height: 100px;
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
Recent changes to the alert group styling meant the alert group container wasn't large enough to accommodate all the alert groups and the low priority group was wrapping down and therefore not visible.

This increases the size of the container so all groups fit.