### PR TITLE
Ensure additional draw downs have amount and month

### DIFF
--- a/app/models/premium_schedule.rb
+++ b/app/models/premium_schedule.rb
@@ -32,6 +32,7 @@ class PremiumSchedule < ActiveRecord::Base
   validate :initial_draw_amount_is_within_limit
   validate :total_draw_amount_less_than_or_equal_to_loan_amount
   validate :validate_capital_repayment_holiday
+  validate :additional_draws_have_amount_and_month
 
   format :initial_draw_amount, with: MoneyFormatter.new
   format :second_draw_amount, with: MoneyFormatter.new
@@ -202,6 +203,21 @@ class PremiumSchedule < ActiveRecord::Base
 
       if initial_capital_repayment_holiday >= repayment_duration
         errors.add(:initial_capital_repayment_holiday, :must_be_lt_loan_duration)
+      end
+    end
+
+    def additional_draws_have_amount_and_month
+      %i(second_draw third_draw fourth_draw).each do |draw_number|
+        amount_attr = "#{draw_number}_amount"
+        month_attr = "#{draw_number}_months"
+        draw_amount = public_send(amount_attr)
+        draw_month = public_send(month_attr)
+
+        if draw_amount.present? && draw_month.blank?
+          errors.add(month_attr, :blank)
+        elsif draw_month.present? && draw_amount.blank?
+          errors.add(amount_attr, :blank)
+        end
       end
     end
 end

--- a/spec/models/premium_schedule_spec.rb
+++ b/spec/models/premium_schedule_spec.rb
@@ -24,12 +24,34 @@ shared_examples_for 'a draw amount validator' do
       before do
         loan.amount = Money.new(7_000_00)
         subject.fourth_draw_amount = nil
+        subject.fourth_draw_months = nil
       end
 
       it 'is valid' do
         expect(subject).to be_valid
       end
     end
+
+    context "but a draw month is missing" do
+      before do
+        subject.second_draw_months = nil
+      end
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context "but a draw amount is missing" do
+      before do
+        subject.second_draw_amount = nil
+      end
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+    end
+
   end
 
   context 'when the total of all draw amounts is less than the loan amount' do
@@ -41,8 +63,11 @@ shared_examples_for 'a draw amount validator' do
       end
     end
 
-    context 'and there are nil draw amounts' do
-      before { subject.fourth_draw_amount = nil }
+    context 'and there are nil draws' do
+      before do
+        subject.fourth_draw_amount = nil
+        subject.fourth_draw_months = nil
+      end
 
       it 'is valid' do
         expect(subject).to be_valid
@@ -60,7 +85,10 @@ shared_examples_for 'a draw amount validator' do
     end
 
     context 'and there are nil draw amounts' do
-      before { subject.fourth_draw_amount = nil }
+      before do
+        subject.fourth_draw_amount = nil
+        subject.fourth_draw_months = nil
+      end
 
       it 'is not valid' do
         expect(subject).not_to be_valid
@@ -131,26 +159,23 @@ describe PremiumSchedule do
     end
 
     %w(
-      second_draw_months
-      third_draw_months
-      fourth_draw_months
+      second_draw
+      third_draw
+      fourth_draw
     ).each do |attr|
-      it "does not require #{attr} if not set" do
-        premium_schedule.send("#{attr}=", nil)
+      it "requires #{attr} months to be 0 or greater if set" do
+        premium_schedule.send("#{attr}_amount=", Money.new(0))
+        premium_schedule.send("#{attr}_months=", -1)
+        expect(premium_schedule).not_to be_valid
+        premium_schedule.send("#{attr}_months=", 0)
         expect(premium_schedule).to be_valid
       end
 
-      it "requires #{attr} to be 0 or greater if set" do
-        premium_schedule.send("#{attr}=", -1)
+      it "requires #{attr} months to be 120 or less if set" do
+        premium_schedule.send("#{attr}_amount=", Money.new(0))
+        premium_schedule.send("#{attr}_months=", 121)
         expect(premium_schedule).not_to be_valid
-        premium_schedule.send("#{attr}=", 0)
-        expect(premium_schedule).to be_valid
-      end
-
-      it "requires #{attr} to be 120 or less if set" do
-        premium_schedule.send("#{attr}=", 121)
-        expect(premium_schedule).not_to be_valid
-        premium_schedule.send("#{attr}=", 120)
+        premium_schedule.send("#{attr}_months=", 120)
         expect(premium_schedule).to be_valid
       end
     end

--- a/spec/presenters/reprofile_draws_loan_change_spec.rb
+++ b/spec/presenters/reprofile_draws_loan_change_spec.rb
@@ -54,25 +54,29 @@ describe ReprofileDrawsLoanChange do
 
       it 'second draw must not be skipped if third or fourth is present' do
         draw_change.second_draw_amount = ''
+        draw_change.second_draw_months = ""
         expect(draw_change).not_to be_valid
 
         draw_change.fourth_draw_amount = ''
+        draw_change.fourth_draw_months = ""
         expect(draw_change).not_to be_valid
 
         draw_change.third_draw_amount = ''
+        draw_change.third_draw_months = ""
         draw_change.fourth_draw_amount = Money.new(100_00)
         expect(draw_change).not_to be_valid
 
-        draw_change.third_draw_amount = ''
         draw_change.fourth_draw_amount = ''
         expect(draw_change).to be_valid
       end
 
       it 'third draw must not be skipped if fourth is present' do
         draw_change.third_draw_amount = ''
+        draw_change.third_draw_months = ""
         expect(draw_change).not_to be_valid
 
         draw_change.fourth_draw_amount = ''
+        draw_change.fourth_draw_months = ""
         expect(draw_change).to be_valid
       end
     end


### PR DESCRIPTION
On a Premium Schedule, an additional draw down could be defined with an amount but no month or a month but no amount. This ensures that both values are present.