### PR TITLE
Lump sum repayment validation fix

### DIFF
--- a/app/presenters/lump_sum_repayment_loan_change.rb
+++ b/app/presenters/lump_sum_repayment_loan_change.rb
@@ -2,6 +2,7 @@ class LumpSumRepaymentLoanChange < LoanChangePresenter
   attr_reader :lump_sum_repayment
   attr_accessible :lump_sum_repayment
 
+  validates_presence_of :initial_draw_amount
   validate :validate_lump_sum_repayment
   validate :validate_outstanding_balance
 
@@ -29,6 +30,8 @@ class LumpSumRepaymentLoanChange < LoanChangePresenter
     end
 
     def validate_outstanding_balance
+      return unless initial_draw_amount.present?
+
       if total_lump_sum_repayments + initial_draw_amount > loan.cumulative_drawn_amount
         errors.add(:initial_draw_amount, :exceeds_amount_remaining)
       end

--- a/spec/presenters/lump_sum_repayment_loan_change_spec.rb
+++ b/spec/presenters/lump_sum_repayment_loan_change_spec.rb
@@ -37,6 +37,12 @@ describe LumpSumRepaymentLoanChange do
     end
 
     describe "#initial_draw_amount" do
+      it "is required" do
+        presenter = build(:lump_sum_repayment_loan_change)
+        presenter.initial_draw_amount = nil
+        expect(presenter).not_to be_valid
+      end
+
       it "cannot exceed the amount remaining on the loan, after all lump sum repayments" do
         loan = FactoryGirl.create(
           :loan,


### PR DESCRIPTION
Handle when initial draw amount is not set. Was raising an exception when blank.