### PR TITLE
Remove default values for secrets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 sudo: false
 bundler_args: --without development
+env:
+  global:
+    - DEVISE_SECRET_KEY=example_secret_key
+    - DEVISE_PEPPER=example_pepper
 before_install:
   - cp config/database.travis.yml config/database.yml
   - export PARALLEL_TEST_PROCESSORS=8

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,8 +2,12 @@
 # Many of these configuration options can be set straight in your model.
 require "statsd"
 
+if ENV['DEVISE_SECRET_KEY'].blank? or ENV['DEVISE_PEPPER'].blank?
+  raise 'Required Devise secrets are not present in the environment'
+end
+
 Devise.setup do |config|
-  config.secret_key = '806c5d2b0b90591ae631ba67d69357b3c960af9dff04bdf3b8c10b98be7e6014ea41e6740f610a332ec034ae6f3f84a2365e129ef8c53e7290dddaeadd46bd83'
+  config.secret_key = ENV['DEVISE_SECRET_KEY']
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
@@ -86,7 +90,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 1000
 
   # Setup a pepper to generate the encrypted password.
-  # config.pepper = "28da3608e63709e887d73b8c73e293362bdfde6a34a9ca94419534bcbffc6eefd4d9e9254c20597047ebd6a0a20f14aba717e934066cfa4bd8ac1c9c13c8a3f5"
+  config.pepper = ENV['DEVISE_PEPPER']
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -x
 bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment --without=development
+
+export DEVISE_SECRET_KEY=example_secret_key
+export DEVISE_PEPPER=example_pepper
+
 RAILS_ENV=test bundle exec rake db:setup
 RAILS_ENV=test bundle exec rake db:migrate
 RAILS_ENV=test COVERAGE=1 bundle exec rake ci:setup:rspec parallel:prepare parallel:spec


### PR DESCRIPTION
We very nearly had a security incident with EFG because of the way we add initializers during deployment. We ended up almost using the public version of the `secret_key` in production.

To stop this from happening, the app must read its config from the environment. This may mean that you have to adjust your development environments to provide these variables.