### PR TITLE
EFG recovery calculation fix

### DIFF
--- a/app/calculators/efg_recovery_calculator.rb
+++ b/app/calculators/efg_recovery_calculator.rb
@@ -9,10 +9,12 @@ class EfgRecoveryCalculator
   end
 
   def amount_due_to_dti
-    non_linked_security_proceeds_efg_debt_amount *
-      recovery.loan_guarantee_rate
+    realisations_attributable * recovery.loan_guarantee_rate
   end
 
+  # This method isn't relevant to EFG but is
+  # needed to maintain a consistent interface with
+  # other recovery calculators
   def amount_due_to_sec_state
     Money.new(0)
   end
@@ -25,17 +27,11 @@ class EfgRecoveryCalculator
     recovery.dti_demand_outstanding
   end
 
-  def total_debt
-    value_of_efg_debt +
-      recovery.outstanding_prior_non_efg_debt +
-      recovery.outstanding_subsequent_non_efg_debt
-  end
-
-  def total_realisations
-    recovery.linked_security_proceeds +
-      recovery.non_linked_security_proceeds
-  end
-
+  # All proceeds from linked security go to repay
+  # EFG lending first. 75% (current guarantee rate) of
+  # this linked security is refunded to BIS.
+  #
+  # The remainder represents how much EFG debt is left
   def remaining_efg_debt
     [
       value_of_efg_debt - recovery.linked_security_proceeds,
@@ -43,6 +39,12 @@ class EfgRecoveryCalculator
     ].max
   end
 
+  # Any non-linked security proceeds are applied
+  # first to any non-EFG borrowing taken out prior to or
+  # simultaneous with the EFG facility.
+  #
+  # Any remaining non-linked security is split between
+  # paying off any remaining EFG and non-EFG debt.
   def remaining_non_linked_security_proceeds
     [
       recovery.non_linked_security_proceeds -
@@ -51,21 +53,32 @@ class EfgRecoveryCalculator
     ].max
   end
 
+  # The amount of remaining non-linked security proceeds
+  # that goes towards paying of EFG debt
   def non_linked_security_proceeds_efg_debt_amount
     remaining_non_linked_security_proceeds *
-      distribution_of_remaining_securities
+      efg_proportion_of_remaining_securities
   end
 
-  def distribution_of_remaining_securities
+  # Calculates what proportion of the remaining non-linked
+  # security goes towards paying off the remaining EFG debt
+  #
+  # This is:
+  # the total remaining EFG debt divided by the sum of
+  # total remaining EFG debt and the subsequent non-EFG
+  # debt balance
+  def efg_proportion_of_remaining_securities
     return 0 unless has_debt?
 
-    remaining_efg_debt / (
-      remaining_efg_debt + recovery.outstanding_subsequent_non_efg_debt)
+    efg_debt_proportion = remaining_efg_debt / (
+                            remaining_efg_debt +
+                            recovery.outstanding_subsequent_non_efg_debt)
+
+    efg_debt_proportion.round(2)
   end
 
   def has_debt?
     [
-      remaining_efg_debt,
       remaining_efg_debt,
       recovery.outstanding_subsequent_non_efg_debt,
     ].any? { |amount| amount != Money.new(0) }

--- a/spec/calculators/efg_recovery_calculator_spec.rb
+++ b/spec/calculators/efg_recovery_calculator_spec.rb
@@ -39,7 +39,7 @@ describe EfgRecoveryCalculator do
       )
       calculator = described_class.new(recovery)
 
-      expect(calculator.amount_due_to_dti).to eq(Money.new(0))
+      expect(calculator.amount_due_to_dti).to eq(Money.new(37_500_00))
     end
   end
 
@@ -87,7 +87,7 @@ describe EfgRecoveryCalculator do
       )
       calculator = described_class.new(recovery)
 
-      expect(calculator.realisations_attributable).to eq(Money.new(58_333_33))
+      expect(calculator.realisations_attributable).to eq(Money.new(58_250_00))
     end
 
     it "reduces the amount due to DTI relative to non-EFG debt" do
@@ -107,30 +107,30 @@ describe EfgRecoveryCalculator do
       )
       calculator = described_class.new(recovery)
 
-      expect(calculator.amount_due_to_dti).to eq(Money.new(6_250_00))
+      expect(calculator.amount_due_to_dti).to eq(Money.new(43_687_50))
     end
   end
 
-  context "with no debt" do
+  context "with remaining non-linked securities" do
     it "calculates the correct amount due to DTI" do
       loan = FactoryGirl.build(
         :loan, :settled,
-        amount: Money.new(100_000_00),
-        dti_demand_outstanding: Money.new(25_075_03),
-        dti_amount_claimed: Money.new(18_806_27),
+        amount: Money.new(70_000_00),
+        dti_demand_outstanding: Money.new(57_166_74),
+        dti_amount_claimed: Money.new(42_875_05),
       )
 
       recovery = setup_recovery(
         loan: loan,
-        outstanding_prior_non_efg_debt: Money.new(0.00),
-        outstanding_subsequent_non_efg_debt: Money.new(0.00),
-        non_linked_security_proceeds: Money.new(0.00),
-        linked_security_proceeds: Money.new(25_075_03),
+        outstanding_prior_non_efg_debt: Money.new(50_000_00),
+        outstanding_subsequent_non_efg_debt: Money.new(30_000_00),
+        non_linked_security_proceeds: Money.new(70_000_00),
+        linked_security_proceeds: Money.new(20_000_00),
       )
 
       calculator = described_class.new(recovery)
 
-      expect(calculator.amount_due_to_dti).to eq(Money.new(0))
+      expect(calculator.amount_due_to_dti).to eq(Money.new(23_250_00))
     end
   end
 

--- a/spec/models/recovery_spec.rb
+++ b/spec/models/recovery_spec.rb
@@ -113,8 +113,8 @@ describe Recovery do
 
         recovery.calculate
 
-        expect(recovery.realisations_attributable).to eq(Money.new(58_333_33))
-        expect(recovery.amount_due_to_dti).to eq(Money.new(6_250_00))
+        expect(recovery.realisations_attributable).to eq(Money.new(58_250_00))
+        expect(recovery.amount_due_to_dti).to eq(Money.new(43_687_50))
         expect(recovery.amount_due_to_sec_state).to eq(Money.new(0))
       end
 

--- a/spec/requests/recovery_spec.rb
+++ b/spec/requests/recovery_spec.rb
@@ -31,8 +31,8 @@ describe 'loan recovery' do
             fill_in_valid_efg_recovery_details
             click_button 'Calculate'
 
-            expect(page).to have_content("£58,333.33")
-            expect(page).to have_content("£6,250.00")
+            expect(page).to have_content("£58,250.00")
+            expect(page).to have_content("£43,687.50")
           }.not_to change(Recovery, :count)
 
           expect {


### PR DESCRIPTION
Linked security proceeds should be included in amount due to DTI. Previously only the EFG proportion of remaining non-linked security proceeds was going to DTI.