### PR TITLE
Manage allow_alert_process

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -139,3 +139,9 @@ fieldset .label {
     width: 500px;
   }
 }
+
+.boolean .hint {
+  color: $medium_grey;
+  display: inline-block;
+  margin-left: 1.5em;
+}

--- a/app/models/lender.rb
+++ b/app/models/lender.rb
@@ -16,7 +16,8 @@ class Lender < ActiveRecord::Base
 
   attr_accessible :can_use_add_cap, :name,
     :organisation_reference_code, :primary_contact_email,
-    :primary_contact_name, :primary_contact_phone, :loan_scheme
+    :primary_contact_name, :primary_contact_phone, :loan_scheme,
+    :allow_alert_process
 
   validates_inclusion_of :can_use_add_cap, in: [true, false]
   validates_inclusion_of :loan_scheme, in: [ EFG_SCHEME ], allow_blank: true

--- a/app/views/lenders/_form.html.erb
+++ b/app/views/lenders/_form.html.erb
@@ -8,6 +8,7 @@
       <%= f.input :primary_contact_phone %>
       <%= f.input :primary_contact_email %>
       <%= f.input :can_use_add_cap, wrapper: :checkbox %>
+      <%= f.input :allow_alert_process, wrapper: :checkbox %>
     </div>
 
     <div class="span6">

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -48,6 +48,7 @@ SimpleForm.setup do |config|
   config.wrappers :checkbox, :tag => 'div', :class => 'control-group', :error_class => 'error' do |b|
     b.wrapper :tag => 'div', :class => 'controls' do |input|
       input.use :label_input
+      input.use :hint, :wrap_with => { tag: :span, class: :hint }
     end
   end
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -10,6 +10,9 @@ en:
       # html: '<abbr title="required">*</abbr>'
     error_notification:
       default_message: "Please review the problems below:"
+    hints:
+      lender:
+        allow_alert_process: "If not enabled, loans for this lender will not be auto-updated by the system (e.g. auto-cancelled, auto-removed etc)"
     labels:
       agreed_draw:
         date_of_change: Date of tranche drawdown
@@ -324,3 +327,7 @@ en:
       loan_status_amendment:
         status_amendment_type: "Type of amendment"
         status_amendment_notes: "Notes"
+
+      lender:
+        allow_alert_process: "Enable loan auto-updating"
+

--- a/spec/requests/lenders_request_spec.rb
+++ b/spec/requests/lenders_request_spec.rb
@@ -81,6 +81,7 @@ describe 'lenders' do
       fill_in 'primary_contact_phone', '987654321'
       fill_in 'primary_contact_email', 'flob@example.com'
       check 'can_use_add_cap'
+      uncheck "allow_alert_process"
 
       click_button 'Update Lender'
 
@@ -91,6 +92,7 @@ describe 'lenders' do
       expect(lender.primary_contact_name).to eq('Flob Bemming')
       expect(lender.primary_contact_phone).to eq('987654321')
       expect(lender.primary_contact_email).to eq('flob@example.com')
+      expect(lender.allow_alert_process).to eq(false)
       expect(lender.can_use_add_cap).to eq(true)
 
       admin_audit = AdminAudit.last!
@@ -148,6 +150,10 @@ describe 'lenders' do
   private
     def check(attribute)
       page.check "lender_#{attribute}"
+    end
+
+    def uncheck(attribute)
+      page.uncheck "lender_#{attribute}"
     end
 
     def fill_in(attribute, value)


### PR DESCRIPTION
Allow Cfe Admins to manage `allow_alert_process`.

This setting toggles whether a lender’s loans are auto-updated by the system (see `LoanAutoUpdater`). A number of lenders have this setting disabled and BBB want it enabled, so this allows them to manage that.